### PR TITLE
Fixed bug where user was sent undefined link

### DIFF
--- a/app/email/index.js
+++ b/app/email/index.js
@@ -19,7 +19,7 @@ const sendPasswordReset = (email, firstName, code) => {
     subject: 'ACM UCSD Membership Portal Password Reset',
     html: ejs.render(passwordResetTemplate, {
       firstName,
-      link: `${config.client.domain}/resetPassword/${code}`,
+      link: `${config.client}/resetPassword/${code}`,
     }),
   };
   sendEmail(data).catch((error) => {


### PR DESCRIPTION
In [`config`](https://github.com/acmucsd/membership-portal/blob/80a18a429d56def8d1e050b2547699b6530c0d49/app/config/index.js#L29), config.client is set to the domain, not config.client.domain.