### PR TITLE
Added specific admin event fetcher

### DIFF
--- a/app/api/v1/event/index.js
+++ b/app/api/v1/event/index.js
@@ -49,7 +49,7 @@ router.route('/adminFetch/:uuid?')
     if (req.params.uuid && req.params.uuid.trim()) {
       Event.findByUUID(req.params.uuid).then((event) => {
         // if event found, return the public event (or admin version if user is admin), else null
-        res.json({ error: null, event: event ? event.getPublic(true) : null});
+        res.json({ error: null, event: event ? event.getPublic(true) : null });
       }).catch(next);
     // else (UUID is not provided), return all events
     } else {
@@ -62,7 +62,7 @@ router.route('/adminFetch/:uuid?')
         res.json({ error: null, events: events.map((e) => e.getPublic(true)) });
       }).catch(next);
     }
-  })
+  });
 
 router.route('/:uuid?')
 


### PR DESCRIPTION
As get events is now public, we had a bug where we still tried to determine the identity of the requester through req.user.isAdmin() even though we didn't run authenticated.

Made the public event get route always return public event info and created route to return admin event info after authentication

Closes #51
