### PR TITLE
split uuid-specific and general event searches

### DIFF
--- a/app/api/v1/event/index.js
+++ b/app/api/v1/event/index.js
@@ -29,36 +29,10 @@ router.get('/future', (req, res, next) => {
   }).catch(next);
 });
 
-router.route('/:uuid?')
+router.route('/:uuid')
 
   /**
-   * Get all events, all events by committee, or a single event. If an event UUID is provided in the URI,
-   * returns the matching event or null if no such event was found. Otherwise if no event UUID is provided
-   * in the URI, returns all events. If the 'committee' field is provided as a query parameter, returns all
-   * events hosted by that committee. Supports pagination using the 'offset' and 'limit' query parameters.
-   */
-  .get((req, res, next) => {
-    // if UUID is provided, return matching event
-    if (req.params.uuid && req.params.uuid.trim()) {
-      Event.findByUUID(req.params.uuid).then((event) => {
-        // if event found, return the public event (or admin version if user is admin), else null
-        res.json({ error: null, event: event ? event.getPublic(req.user.isAdmin()) : null });
-      }).catch(next);
-    // else (UUID is not provided), return all events
-    } else {
-      const offset = parseInt(req.query.offset, 10);
-      const limit = parseInt(req.query.limit, 10);
-      const { committee } = req.query;
-      // if committee is provided, return all events for committee, else return all events
-      const getEvents = committee ? Event.getCommitteeEvents(committee, offset, limit) : Event.getAll(offset, limit);
-      getEvents.then((events) => {
-        res.json({ error: null, events: events.map((e) => e.getPublic(req.user.isAdmin())) });
-      }).catch(next);
-    }
-  })
-
-  /**
-   * All further requests on this route require admin access.
+   * All further requests on this route require authentication and admin access.
    */
   .all(authenticated, (req, res, next) => {
     if (!req.user.isAdmin()) return next(new error.Forbidden());
@@ -66,22 +40,12 @@ router.route('/:uuid?')
   })
 
   /**
-   * Adds an event, given an 'event' object in the request body, and returns the newly created event upon
-   * success. Required fields: title, description, start, end, attendanceCode, pointValue, requiresStaff.
-   * Optional fields: committee, thumbnail, cover, location, eventLink, staffPointBonus. All other fields
-   * will be ignored.
+   * Given an event UUID in the URI, return the matching event or null if no such event was found.
    */
-  .post((req, res, next) => {
-    if (req.params.uuid) return next(new error.BadRequest('UUID must not be provided'));
-    if (!req.body.event) return next(new error.BadRequest('Event must be provided'));
-
-    const datesProvided = req.body.event.start && req.body.event.end;
-    if (datesProvided && new Date(req.body.event.start) > new Date(req.body.event.end)) {
-      return next(new error.BadRequest('Start date must be before end date'));
-    }
-
-    Event.create(Event.sanitize(req.body.event)).then((event) => {
-      res.json({ error: null, event: event.getPublic() });
+  .get((req, res, next) => {
+    Event.findByUUID(req.params.uuid).then((event) => {
+      // if event found, return the public event (or admin version if user is admin), else null
+      res.json({ error: null, event: event ? event.getPublic(req.user.isAdmin()) : null });
     }).catch(next);
   })
 
@@ -117,6 +81,52 @@ router.route('/:uuid?')
     if (!req.params.uuid) return next(new error.BadRequest('UUID must be provided'));
     Event.destroyByUUID(req.params.uuid).then((numDeleted) => {
       res.json({ error: null, numDeleted });
+    }).catch(next);
+  });
+
+router.route('/')
+
+  /**
+   * Get all events, with an optional filter for all events by a specific committee. If the 'committee' field
+   * is provided as a query parameter, returns all events hosted by that committee. Supports pagination using
+   * the 'offset' and 'limit' query parameters.
+   */
+  .get((req, res, next) => {
+    const offset = parseInt(req.query.offset, 10);
+    const limit = parseInt(req.query.limit, 10);
+    const { committee } = req.query;
+    // if committee is provided, return all events for committee, else return all events
+    const getEvents = committee ? Event.getCommitteeEvents(committee, offset, limit) : Event.getAll(offset, limit);
+    getEvents.then((events) => {
+      res.json({ error: null, events: events.map((e) => e.getPublic(false)) });
+    }).catch(next);
+  })
+
+  /**
+   * All further requests on this route require authentication and admin access.
+   */
+  .all(authenticated, (req, res, next) => {
+    if (!req.user.isAdmin()) return next(new error.Forbidden());
+    return next();
+  })
+
+  /**
+   * Adds an event, given an 'event' object in the request body, and returns the newly created event upon
+   * success. Required fields: title, description, start, end, attendanceCode, pointValue, requiresStaff.
+   * Optional fields: committee, thumbnail, cover, location, eventLink, staffPointBonus. All other fields
+   * will be ignored.
+   */
+  .post((req, res, next) => {
+    if (req.params.uuid) return next(new error.BadRequest('UUID must not be provided'));
+    if (!req.body.event) return next(new error.BadRequest('Event must be provided'));
+
+    const datesProvided = req.body.event.start && req.body.event.end;
+    if (datesProvided && new Date(req.body.event.start) > new Date(req.body.event.end)) {
+      return next(new error.BadRequest('Start date must be before end date'));
+    }
+
+    Event.create(Event.sanitize(req.body.event)).then((event) => {
+      res.json({ error: null, event: event.getPublic() });
     }).catch(next);
   });
 


### PR DESCRIPTION
Fixes #51. With this change, only admins can request an event by its UUID but anyone can search for only public versions of all events.