### PR TITLE
Create API user/permissions for editing account type of users

### DIFF
--- a/app/api/v1/user/index.js
+++ b/app/api/v1/user/index.js
@@ -76,6 +76,13 @@ router.route('/')
     }
   });
 
+router.get('/:id', (req, res, next) => {
+  User.findByUUID(req.params.id).then((user) => {
+    if (req.params.id !== req.user.uuid) user = user.getPublicProfile();
+    res.json({ error: null, user });
+  }).catch(next);
+});
+
 /**
  * Gets the current user's public activity (account creation, events attendances, etc).
  */

--- a/app/db/models/user.js
+++ b/app/db/models/user.js
@@ -235,6 +235,7 @@ module.exports = (Sequelize, db) => {
   User.prototype.getUserProfile = function () {
     return {
       uuid: this.getDataValue('uuid'),
+      accountType: this.getDataValue('accessType'),
       firstName: this.getDataValue('firstName'),
       lastName: this.getDataValue('lastName'),
       profilePicture: this.getDataValue('profilePicture'),

--- a/app/db/models/user.js
+++ b/app/db/models/user.js
@@ -228,6 +228,8 @@ module.exports = (Sequelize, db) => {
       firstName: this.getDataValue('firstName'),
       lastName: this.getDataValue('lastName'),
       profilePicture: this.getDataValue('profilePicture'),
+      graduationYear: this.getDataValue('graduationYear'),
+      major: this.getDataValue('major'),
       points: this.getDataValue('points'),
     };
   };

--- a/app/db/models/user.js
+++ b/app/db/models/user.js
@@ -223,6 +223,10 @@ module.exports = (Sequelize, db) => {
     return this.increment({ points });
   };
 
+  User.prototype.setAccessType = function (target) {
+    return this.update({ accessType: target });
+  };
+
   User.prototype.getPublicProfile = function () {
     return {
       firstName: this.getDataValue('firstName'),


### PR DESCRIPTION
Modelled on user/bonus API.

Note that this allows users to edit their own access type as well (so it is potentially dangerous to use directly). Maybe we should add a check to disallow admins from being downgraded.

Closes #45 
