### PR TITLE
reconfigure s3 file uploads

### DIFF
--- a/src/api/v1/user/index.js
+++ b/src/api/v1/user/index.js
@@ -21,13 +21,12 @@ router.get('/activity', (req, res, next) => {
 router.post('/picture', (req, res, next) => {
   try {
     const fileUpload = Storage.getFileUpload('image', 256);
-    fileUpload(req, res, async (err) => {
+    fileUpload(req, res, (err) => {
       if (err) next(err);
       if (req.file) {
-        const { path, originalname } = req.file;
-        const profileUrl = await Storage.uploadToS3(path, originalname, req.user.uuid);
-        req.user.updateProfilePicture(profileUrl);
-        res.json({ error: null, profileUrl });
+        const { location } = req.file;
+        req.user.updateProfilePicture(location);
+        res.json({ error: null, location });
       }
     });
   } catch (err) {

--- a/src/api/v1/user/index.js
+++ b/src/api/v1/user/index.js
@@ -2,7 +2,7 @@ const Sequelize = require('sequelize');
 const express = require('express');
 const error = require('../../../error');
 const { User, Activity, db } = require('../../../db');
-const storage = require('../../../storage');
+const Storage = require('../../../storage');
 
 const router = express.Router();
 
@@ -18,10 +18,11 @@ router.get('/activity', (req, res, next) => {
 /**
  * Uploads a profile picture for the current user.
  */
-router.post('/picture', storage.single('image'), (req, res, next) => {
-  const { location } = req.file;
-  req.user.updateProfilePicture(location);
-  res.json({ error: null, location });
+router.post('/picture', Storage.upload.single('image'), async (req, res, next) => {
+  const { path, originalname } = req.file
+  const profile_url = await Storage.uploadToS3(path, originalname, req.user.uuid)
+  req.user.updateProfilePicture(profile_url);
+  res.json({ error: null, profile_url });
 });
 
 router.route('/milestone')

--- a/src/api/v1/user/index.js
+++ b/src/api/v1/user/index.js
@@ -19,17 +19,20 @@ router.get('/activity', (req, res, next) => {
  * Uploads a profile picture for the current user.
  */
 router.post('/picture', (req, res, next) => {
-  Storage.upload(req, res, async (err) => {
-    if (err) next(err);
-    try {
-      const { path, originalname } = req.file;
-      const profileUrl = await Storage.uploadToS3(path, originalname, req.user.uuid);
-      req.user.updateProfilePicture(profileUrl);
-      res.json({ error: null, profileUrl });
-    } catch (er) {
-      next(er);
-    }
-  });
+  try {
+    const fileUpload = Storage.getFileUpload('image', 256);
+    fileUpload(req, res, async (err) => {
+      if (err) next(err);
+      if (req.file) {
+        const { path, originalname } = req.file;
+        const profileUrl = await Storage.uploadToS3(path, originalname, req.user.uuid);
+        req.user.updateProfilePicture(profileUrl);
+        res.json({ error: null, profileUrl });
+      }
+    });
+  } catch (err) {
+    next(err);
+  }
 });
 
 router.route('/milestone')

--- a/src/api/v1/user/index.js
+++ b/src/api/v1/user/index.js
@@ -20,14 +20,14 @@ router.get('/activity', (req, res, next) => {
  */
 router.post('/picture', (req, res, next) => {
   Storage.upload(req, res, async (err) => {
-    if(err) next(err);
+    if (err) next(err);
     try {
-      const { path, originalname } = req.file
-      const profile_url = await Storage.uploadToS3(path, originalname, req.user.uuid)
-      req.user.updateProfilePicture(profile_url);
-      res.json({ error: null, profile_url });
-    } catch(error) {
-      next(error)
+      const { path, originalname } = req.file;
+      const profileUrl = await Storage.uploadToS3(path, originalname, req.user.uuid);
+      req.user.updateProfilePicture(profileUrl);
+      res.json({ error: null, profileUrl });
+    } catch (er) {
+      next(er);
     }
   });
 });

--- a/src/api/v1/user/index.js
+++ b/src/api/v1/user/index.js
@@ -18,11 +18,18 @@ router.get('/activity', (req, res, next) => {
 /**
  * Uploads a profile picture for the current user.
  */
-router.post('/picture', Storage.upload.single('image'), async (req, res, next) => {
-  const { path, originalname } = req.file
-  const profile_url = await Storage.uploadToS3(path, originalname, req.user.uuid)
-  req.user.updateProfilePicture(profile_url);
-  res.json({ error: null, profile_url });
+router.post('/picture', (req, res, next) => {
+  Storage.upload(req, res, async (err) => {
+    if(err) next(err);
+    try {
+      const { path, originalname } = req.file
+      const profile_url = await Storage.uploadToS3(path, originalname, req.user.uuid)
+      req.user.updateProfilePicture(profile_url);
+      res.json({ error: null, profile_url });
+    } catch(error) {
+      next(error)
+    }
+  });
 });
 
 router.route('/milestone')

--- a/src/db/seeds/0001-users.js
+++ b/src/db/seeds/0001-users.js
@@ -54,6 +54,17 @@ module.exports = {
     points: 160,
     graduationYear: 2022,
     major: 'Computer Engineering',
+  }, {
+    uuid: '7dc03709-4a52-4ff1-b886-982a56d3d0de',
+    email: 'smhariha@ucsd.edu',
+    accessType: 'STANDARD',
+    state: 'ACTIVE',
+    firstName: 'Shravan',
+    lastName: 'Hariharan',
+    hash: '$2b$10$WNZRaGHvj3blWAtosHrSDeH4wuSkpwmEVq4obpKr4nujs4XavIgmG',
+    points: 750,
+    graduationYear: 2023,
+    major: 'Computer Science',
   }]),
 
   down: (queryInterface, Sequelize) => queryInterface.bulkDelete('Users', null, {}),

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -6,7 +6,7 @@ const config = require('../config');
 const log = require('../logger');
 
 // sets maximum file size for profile pictures to 256 KB
-const MAXIMUM_FILE_SIZE = 256 * 1024;
+const BYTES_PER_KILOBYTE = 1024;
 
 const s3 = new aws.S3({
   apiVersion: '2006-03-01',
@@ -32,11 +32,15 @@ const uploadToS3 = async (filePath, originalName, uuid) => {
   return profileUrl;
 };
 
-const upload = multer({
-  dest: './src/storage/uploads',
-  limits: {
-    fileSize: MAXIMUM_FILE_SIZE,
-  },
-}).single('image');
+const getFileUpload = (fileTag, maxFileSize) => {
+  const fileUpload = multer({
+    dest: './src/storage/uploads',
+    limits: {
+      fileSize: maxFileSize * BYTES_PER_KILOBYTE,
+    },
+  }).single(fileTag);
+  return fileUpload;
+};
 
-module.exports = { upload, uploadToS3 };
+
+module.exports = { getFileUpload, uploadToS3 };

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -1,9 +1,9 @@
 const aws = require('aws-sdk');
 const multer = require('multer');
 const path = require('path');
+const fs = require('fs');
 const config = require('../config');
 const log = require('../logger');
-const fs = require('fs')
 
 // sets maximum file size for profile pictures to 256 KB
 const MAXIMUM_FILE_SIZE = 256 * 1024;
@@ -21,24 +21,22 @@ const uploadToS3 = async (filePath, originalName, uuid) => {
     Body: fileData,
     Bucket: config.s3.bucket,
     Key: `portal/profiles/${uuid}${path.extname(originalName)}`,
-  }
-  const profile_url = await s3.upload(params).promise()
-    .then((data) => {
-      return data.Location
-    })
+  };
+  const profileUrl = await s3.upload(params).promise()
+    .then((data) => data.Location)
     .catch((error) => {
       log.warn(`Failed to upload profile picture to S3: ${error}`);
-    })
+    });
 
   fs.unlinkSync(filePath);
-  return profile_url;
-}
+  return profileUrl;
+};
 
 const upload = multer({
   dest: './src/storage/uploads',
   limits: {
-    fileSize: MAXIMUM_FILE_SIZE
-  }
-}).single("image");
+    fileSize: MAXIMUM_FILE_SIZE,
+  },
+}).single('image');
 
 module.exports = { upload, uploadToS3 };

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -2,6 +2,7 @@ const aws = require('aws-sdk');
 const multer = require('multer');
 const path = require('path');
 const config = require('../config');
+const log = require('../logger');
 const fs = require('fs')
 
 // sets maximum file size for profile pictures to 256 KB
@@ -19,14 +20,14 @@ const uploadToS3 = async (filePath, originalName, uuid) => {
     ACL: 'public-read',
     Body: fileData,
     Bucket: config.s3.bucket,
-    Key: `portal/profiles_test/${uuid}${path.extname(originalName)}`,
+    Key: `portal/profiles/${uuid}${path.extname(originalName)}`,
   }
   const profile_url = await s3.upload(params).promise()
     .then((data) => {
       return data.Location
     })
-    .catch((err) => {
-      console.log(err)
+    .catch((error) => {
+      log.warn(`Failed to upload profile picture to S3: ${error}`);
     })
 
   fs.unlinkSync(filePath);
@@ -38,6 +39,6 @@ const upload = multer({
   limits: {
     fileSize: MAXIMUM_FILE_SIZE
   }
-})
+}).single("image");
 
 module.exports = { upload, uploadToS3 };

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -1,9 +1,8 @@
 const aws = require('aws-sdk');
 const multer = require('multer');
+const multerS3 = require('multer-s3');
 const path = require('path');
-const fs = require('fs');
 const config = require('../config');
-const log = require('../logger');
 
 // sets maximum file size for profile pictures to 256 KB
 const BYTES_PER_KILOBYTE = 1024;
@@ -14,27 +13,16 @@ const s3 = new aws.S3({
   credentials: config.s3.credentials,
 });
 
-const uploadToS3 = async (filePath, originalName, uuid) => {
-  const fileData = fs.readFileSync(filePath);
-  const params = {
-    ACL: 'public-read',
-    Body: fileData,
-    Bucket: config.s3.bucket,
-    Key: `portal/profiles/${uuid}${path.extname(originalName)}`,
-  };
-  const profileUrl = await s3.upload(params).promise()
-    .then((data) => data.Location)
-    .catch((error) => {
-      log.warn(`Failed to upload profile picture to S3: ${error}`);
-    });
-
-  fs.unlinkSync(filePath);
-  return profileUrl;
-};
-
 const getFileUpload = (fileTag, maxFileSize) => {
   const fileUpload = multer({
-    dest: './src/storage/uploads',
+    storage: multerS3({
+      s3,
+      bucket: config.s3.bucket,
+      acl: 'public-read',
+      key: (req, file, next) => {
+        next(null, `portal/profiles/${req.user.uuid}${path.extname(file.originalname)}`);
+      },
+    }),
     limits: {
       fileSize: maxFileSize * BYTES_PER_KILOBYTE,
     },
@@ -43,4 +31,4 @@ const getFileUpload = (fileTag, maxFileSize) => {
 };
 
 
-module.exports = { getFileUpload, uploadToS3 };
+module.exports = { getFileUpload };

--- a/src/storage/uploads/README.md
+++ b/src/storage/uploads/README.md
@@ -1,0 +1,1 @@
+Temporary storage for uploaded files

--- a/src/storage/uploads/README.md
+++ b/src/storage/uploads/README.md
@@ -1,1 +1,0 @@
-Temporary storage for uploaded files


### PR DESCRIPTION
This is just a sample to demonstrate how a more OOP file upload service would look like and to get feedback to see if we really want to change to this sort of service. Changes still need to be made but the core functionality works the exact same (I still need to do error handling/final touches).

Essentially, I removed `multer-s3` and reconfigured `multer` to pipe the file into the s3 storage service (`src/storage/index.js`) where the file is uploaded to s3. The only drawback is that the file _has_ to be written to local storage in order for _any other s3 upload library other than `multer-s3`_ to process its contents. `multer-s3` is the only s3 uploading library that does not require writing/deleting to disk since its already configured w/ `multer`. The file is promptly deleted from disk after being uploaded to s3, and rest of the functionality is the same.

I'd like to hear your thoughts on this trade-off of cleaner, more object-oriented code and potentially slower response time due to writing/deleting every file vs extensive middleware use w/ faster response times. I don't notice any substantial response time increase, but definitely something to consider if we plan on making this change.  

