### PR TITLE
Handle duplicate email error

### DIFF
--- a/src/api/v1/auth/index.js
+++ b/src/api/v1/auth/index.js
@@ -92,12 +92,12 @@ router.post('/register', (req, res, next) => {
         .then(() => user)
         .catch(() => {
           throw new error.BadRequest(`Something went wrong with sending email verification to ${user.email}`);
-        }));
+        })).catch(next);
     })).then((user) => {
       log.info('user authentication (registration)', { request_id: req.id, user_uuid: user.uuid });
       res.json({ error: null, user: user.getPublicProfile() });
       Activity.accountCreated(user.uuid);
-    });
+    }).catch(next);
   }).catch(next);
 });
 


### PR DESCRIPTION
Add `catch` statements for duplicate email error. The db handler doesn't see the error since its thrown at the db layer and wasn't caught at the api layer, where the error handler catches errors (via `next`). 