### PR TITLE
added event filtering

### DIFF
--- a/api/controllers/EventController.ts
+++ b/api/controllers/EventController.ts
@@ -34,7 +34,6 @@ export class EventController {
   @Get('/past')
   async getPastEvents(@QueryParams() options: EventSearchOptions,
     @AuthenticatedUser() user: UserModel): Promise<GetPastEventsResponse> {
-      console.log(options);
     const canSeeAttendanceCode = !!user && PermissionsService.canEditEvents(user);
     const events = await this.eventService.getPastEvents(canSeeAttendanceCode, options);
     return { error: null, events };

--- a/api/controllers/EventController.ts
+++ b/api/controllers/EventController.ts
@@ -34,8 +34,9 @@ export class EventController {
   @Get('/past')
   async getPastEvents(@QueryParams() options: EventSearchOptions,
     @AuthenticatedUser() user: UserModel): Promise<GetPastEventsResponse> {
+      console.log(options);
     const canSeeAttendanceCode = !!user && PermissionsService.canEditEvents(user);
-    const events = await this.eventService.getPastEvents(canSeeAttendanceCode, options.offset, options.limit);
+    const events = await this.eventService.getPastEvents(canSeeAttendanceCode, options);
     return { error: null, events };
   }
 
@@ -44,7 +45,7 @@ export class EventController {
   async getFutureEvents(@QueryParams() options: EventSearchOptions,
     @AuthenticatedUser() user: UserModel): Promise<GetFutureEventsResponse> {
     const canSeeAttendanceCode = !!user && PermissionsService.canEditEvents(user);
-    const events = await this.eventService.getFutureEvents(canSeeAttendanceCode, options.offset, options.limit);
+    const events = await this.eventService.getFutureEvents(canSeeAttendanceCode, options);
     return { error: null, events };
   }
 
@@ -92,7 +93,7 @@ export class EventController {
   @Get()
   async getAllEvents(@QueryParams() options: EventSearchOptions, @AuthenticatedUser() user: UserModel) {
     const canSeeAttendanceCode = !!user && PermissionsService.canEditEvents(user);
-    const events = await this.eventService.getAllEvents(canSeeAttendanceCode, options.offset, options.limit);
+    const events = await this.eventService.getAllEvents(canSeeAttendanceCode, options);
     return { error: null, events };
   }
 

--- a/api/validators/EventControllerRequests.ts
+++ b/api/validators/EventControllerRequests.ts
@@ -84,6 +84,9 @@ export class EventPatches extends OptionalEventProperties implements IEvent {
 
 export class EventSearchOptions implements IEventSearchOptions {
   @Allow()
+  committee?: string;
+
+  @Allow()
   offset?: number;
 
   @Allow()

--- a/services/EventService.ts
+++ b/services/EventService.ts
@@ -3,7 +3,7 @@ import { InjectManager } from 'typeorm-typedi-extensions';
 import { NotFoundError } from 'routing-controllers';
 import { EntityManager } from 'typeorm';
 import { EventModel } from '../models/EventModel';
-import { Uuid, PublicEvent, Event } from '../types';
+import { Uuid, PublicEvent, Event, EventSearchOptions } from '../types';
 import Repositories from '../repositories';
 import { UserError } from '../utils/Errors';
 
@@ -22,26 +22,26 @@ export default class EventService {
     return eventCreated.getPublicEvent();
   }
 
-  public async getAllEvents(canSeeAttendanceCode = false, offset = 0, limit = 0): Promise<PublicEvent[]> {
+  public async getAllEvents(canSeeAttendanceCode = false, options: EventSearchOptions): Promise<PublicEvent[]> {
     const events = await this.entityManager.transaction(async (txn) => {
       const eventRepository = Repositories.event(txn);
-      return eventRepository.getAllEvents(offset, limit);
+      return eventRepository.getAllEvents(options);
     });
     return events.map((e) => e.getPublicEvent(canSeeAttendanceCode));
   }
 
-  public async getPastEvents(canSeeAttendanceCode = false, offset = 0, limit = 0): Promise<PublicEvent[]> {
+  public async getPastEvents(canSeeAttendanceCode = false, options: EventSearchOptions): Promise<PublicEvent[]> {
     const events = await this.entityManager.transaction(async (txn) => {
       const eventRepository = Repositories.event(txn);
-      return eventRepository.getPastEvents(offset, limit);
+      return eventRepository.getPastEvents(options);
     });
     return events.map((e) => e.getPublicEvent(canSeeAttendanceCode));
   }
 
-  public async getFutureEvents(canSeeAttendanceCode = false, offset = 0, limit = 0): Promise<PublicEvent[]> {
+  public async getFutureEvents(canSeeAttendanceCode = false, options: EventSearchOptions): Promise<PublicEvent[]> {
     const events = await this.entityManager.transaction(async (txn) => {
       const eventRepository = Repositories.event(txn);
-      return eventRepository.getFutureEvents(offset, limit);
+      return eventRepository.getFutureEvents(options);
     });
     return events.map((e) => e.getPublicEvent(canSeeAttendanceCode));
   }

--- a/types/ApiRequests.ts
+++ b/types/ApiRequests.ts
@@ -104,6 +104,12 @@ export interface AttendEventRequest {
   asStaff?: boolean;
 }
 
+export interface EventSearchOptions {
+  offset?: number;
+  limit?: number;
+  committee?: string;
+}
+
 // MERCH STORE
 
 export interface CreateMerchCollectionRequest {

--- a/types/index.ts
+++ b/types/index.ts
@@ -3,8 +3,3 @@ export * from './ApiRequests';
 export * from './ApiResponses';
 
 export type File = Express.Multer.File;
-
-export interface EventSearchOptions {
-  offset?: number;
-  limit?: number;
-}


### PR DESCRIPTION
Adds a query parameter `committee` to the event search routes. Side note: PR #120 (sliding leaderboards) adds a `Pagination` class that'd be nice to refactor `EventSearchOptions` with.