### PR TITLE
fixed paging for sliding leaderboards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@acmucsd/membership-portal",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@acmucsd/membership-portal",
-  "version": "2.0.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acmucsd/membership-portal",
-  "version": "2.0.0",
+  "version": "2.2.1",
   "description": "REST API for ACM UCSD's membership portal.",
   "main": "index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acmucsd/membership-portal",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "REST API for ACM UCSD's membership portal.",
   "main": "index.d.ts",
   "files": [

--- a/repositories/LeaderboardRepository.ts
+++ b/repositories/LeaderboardRepository.ts
@@ -1,4 +1,5 @@
 import { EntityRepository, Not, Raw } from 'typeorm';
+import * as moment from 'moment';
 import { ActivityModel } from '../models/ActivityModel';
 import { UserModel } from '../models/UserModel';
 import { UserAccessType, UserState } from '../types';
@@ -29,6 +30,7 @@ export class LeaderboardRepository extends BaseRepository<UserModel> {
           .from(ActivityModel, 'activity')
           .where('"timestamp" >= :from')
           .groupBy('"user"')
+          .orderBy('points', 'DESC')
           .skip(offset)
           .take(limit),
         'totals',
@@ -39,7 +41,7 @@ export class LeaderboardRepository extends BaseRepository<UserModel> {
       .andWhere(`NOT state = '${UserState.BLOCKED}'`)
       .andWhere(`NOT state = '${UserState.PENDING}'`)
       .orderBy('points', 'DESC')
-      // .cache(`sliding_leaderboard_from_${from}`, moment.duration(1, 'hour').asMilliseconds())
+      .cache(LeaderboardRepository.cacheDuration())
       .getRawAndEntities();
     const userPoints = new Map(users.raw.map((u) => [u.usr_uuid, Number(u.points)]));
     return users.entities.map((u) => this.repository.merge(u, { points: userPoints.get(u.uuid) }));
@@ -56,6 +58,7 @@ export class LeaderboardRepository extends BaseRepository<UserModel> {
           .from(ActivityModel, 'activity')
           .where('"timestamp" >= :from AND "timestamp" <= :to')
           .groupBy('"user"')
+          .orderBy('points', 'DESC')
           .skip(offset)
           .take(limit),
         'totals',
@@ -67,9 +70,13 @@ export class LeaderboardRepository extends BaseRepository<UserModel> {
       .andWhere(`NOT state = '${UserState.BLOCKED}'`)
       .andWhere(`NOT state = '${UserState.PENDING}'`)
       .orderBy('points', 'DESC')
-      // .cache(`sliding_leaderboard_from_${from}_to_${to}`, moment.duration(1, 'hour').asMilliseconds())
+      .cache(LeaderboardRepository.cacheDuration())
       .getRawAndEntities();
     const userPoints = new Map(users.raw.map((u) => [u.usr_uuid, Number(u.points)]));
     return users.entities.map((u) => this.repository.merge(u, { points: userPoints.get(u.uuid) }));
+  }
+
+  private static cacheDuration() {
+    return moment.duration(1, 'hour').asMilliseconds();
   }
 }

--- a/repositories/LeaderboardRepository.ts
+++ b/repositories/LeaderboardRepository.ts
@@ -41,7 +41,6 @@ export class LeaderboardRepository extends BaseRepository<UserModel> {
       .andWhere(`NOT state = '${UserState.BLOCKED}'`)
       .andWhere(`NOT state = '${UserState.PENDING}'`)
       .orderBy('points', 'DESC')
-      .cache(LeaderboardRepository.cacheDuration())
       .getRawAndEntities();
     const userPoints = new Map(users.raw.map((u) => [u.usr_uuid, Number(u.points)]));
     return users.entities.map((u) => this.repository.merge(u, { points: userPoints.get(u.uuid) }));
@@ -70,13 +69,9 @@ export class LeaderboardRepository extends BaseRepository<UserModel> {
       .andWhere(`NOT state = '${UserState.BLOCKED}'`)
       .andWhere(`NOT state = '${UserState.PENDING}'`)
       .orderBy('points', 'DESC')
-      .cache(LeaderboardRepository.cacheDuration())
+      .cache(moment.duration(1, 'hour').asMilliseconds())
       .getRawAndEntities();
     const userPoints = new Map(users.raw.map((u) => [u.usr_uuid, Number(u.points)]));
     return users.entities.map((u) => this.repository.merge(u, { points: userPoints.get(u.uuid) }));
-  }
-
-  private static cacheDuration() {
-    return moment.duration(1, 'hour').asMilliseconds();
   }
 }

--- a/repositories/LeaderboardRepository.ts
+++ b/repositories/LeaderboardRepository.ts
@@ -1,5 +1,4 @@
 import { EntityRepository, Not, Raw } from 'typeorm';
-import * as moment from 'moment';
 import { ActivityModel } from '../models/ActivityModel';
 import { UserModel } from '../models/UserModel';
 import { UserAccessType, UserState } from '../types';
@@ -40,7 +39,7 @@ export class LeaderboardRepository extends BaseRepository<UserModel> {
       .andWhere(`NOT state = '${UserState.BLOCKED}'`)
       .andWhere(`NOT state = '${UserState.PENDING}'`)
       .orderBy('points', 'DESC')
-      .cache(`sliding_leaderboard_from_${from}`, moment.duration(1, 'hour').asMilliseconds())
+      // .cache(`sliding_leaderboard_from_${from}`, moment.duration(1, 'hour').asMilliseconds())
       .getRawAndEntities();
     const userPoints = new Map(users.raw.map((u) => [u.usr_uuid, Number(u.points)]));
     return users.entities.map((u) => this.repository.merge(u, { points: userPoints.get(u.uuid) }));
@@ -68,7 +67,7 @@ export class LeaderboardRepository extends BaseRepository<UserModel> {
       .andWhere(`NOT state = '${UserState.BLOCKED}'`)
       .andWhere(`NOT state = '${UserState.PENDING}'`)
       .orderBy('points', 'DESC')
-      .cache(`sliding_leaderboard_from_${from}_to_${to}`, moment.duration(1, 'hour').asMilliseconds())
+      // .cache(`sliding_leaderboard_from_${from}_to_${to}`, moment.duration(1, 'hour').asMilliseconds())
       .getRawAndEntities();
     const userPoints = new Map(users.raw.map((u) => [u.usr_uuid, Number(u.points)]));
     return users.entities.map((u) => this.repository.merge(u, { points: userPoints.get(u.uuid) }));


### PR DESCRIPTION
I moved the `offset`/`limit` for paging to the subquery to cut down on the number of rows in the inner join but forgot to also move the `ORDER BY points DESC` to the subquery.