### PR TITLE
Throw UserError when an event update reuses an attendance code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@acmucsd/membership-portal",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acmucsd/membership-portal",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "REST API for ACM UCSD's membership portal.",
   "main": "index.d.ts",
   "files": [

--- a/services/EventService.ts
+++ b/services/EventService.ts
@@ -60,6 +60,10 @@ export default class EventService {
       const eventRepository = Repositories.event(txn);
       const currentEvent = await eventRepository.findByUuid(uuid);
       if (!currentEvent) throw new NotFoundError('Event not found');
+      if (changes.attendanceCode) {
+        const isUnusedAttendanceCode = eventRepository.isUnusedAttendanceCode(changes.attendanceCode);
+        if (!isUnusedAttendanceCode) throw new UserError('Attendance code has already been used');
+      }
       return eventRepository.upsertEvent(currentEvent, changes);
     });
     return updatedEvent.getPublicEvent(true);

--- a/services/EventService.ts
+++ b/services/EventService.ts
@@ -60,7 +60,7 @@ export default class EventService {
       const eventRepository = Repositories.event(txn);
       const currentEvent = await eventRepository.findByUuid(uuid);
       if (!currentEvent) throw new NotFoundError('Event not found');
-      if (changes.attendanceCode) {
+      if (changes.attendanceCode !== currentEvent.attendanceCode) {
         const isUnusedAttendanceCode = eventRepository.isUnusedAttendanceCode(changes.attendanceCode);
         if (!isUnusedAttendanceCode) throw new UserError('Attendance code has already been used');
       }


### PR DESCRIPTION
There was a QueryFailedError because an event attempted to reuse an existing attendance code. The event creation endpoint has an attendance code check, but the event update endpoint doesn't, so this PR adds that check to the event update endpoint.