### PR TITLE
Allow user bio to be empty on update

### DIFF
--- a/api/validators/UserControllerRequests.ts
+++ b/api/validators/UserControllerRequests.ts
@@ -1,4 +1,4 @@
-import { ValidateNested, IsNotEmpty, IsDefined } from 'class-validator';
+import { ValidateNested, IsDefined, Allow } from 'class-validator';
 import { Type } from 'class-transformer';
 import { IsValidName, IsValidMajor, IsValidGraduationYear, HasMatchingPasswords } from '../decorators/Validators';
 import {
@@ -26,7 +26,7 @@ export class UserPatches implements IUserPatches {
   @IsValidGraduationYear()
   graduationYear?: number;
 
-  @IsNotEmpty()
+  @Allow()
   bio?: string;
 
   @Type(() => PasswordUpdate)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@acmucsd/membership-portal",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acmucsd/membership-portal",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "REST API for ACM UCSD's membership portal.",
   "main": "index.d.ts",
   "files": [


### PR DESCRIPTION
Previously users wouldn't be able to clear their bios after updating them since our validation didn't accept empty strings, so this change allows empty bios to be sent.