### PR TITLE
Fix npm build to include email templates properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "types/*.d.ts"
   ],
   "scripts": {
-    "build": "tsc && cp -r templates/ build/templates/",
+    "build": "tsc && cp -r templates build/templates",
     "start": "node build/index.js",
     "test": "jest --config jest.config.json --runInBand",
     "dev": "nodemon -L -e ts -i node_modules -i .git -V index.ts",


### PR DESCRIPTION
Closes #223.

Fixed issue by copying the entire directory into the `build` directory, and NOT into the `build/templates` directory.

`cp` is weird with slashes, which is what made the difference here. Basically, adding the slash to the end of `build/templates/` caused the entire folder itself to be copied inside, causing unnecessary nesting (final result was `templates -> build/templates/templates`).
