### PR TITLE
Resolve Cart Verification Bug

### DIFF
--- a/services/MerchStoreService.ts
+++ b/services/MerchStoreService.ts
@@ -395,9 +395,7 @@ export default class MerchStoreService {
   }
 
   public async validateOrder(originalOrder: MerchItemOptionAndQuantity[], user: UserModel): Promise<void> {
-    return this.transactions.readWrite(async (txn) => {
-      this.validateOrderInTransaction(originalOrder, user, txn);
-    });
+    return this.transactions.readWrite(async (txn) => this.validateOrderInTransaction(originalOrder, user, txn));
   }
 
   /**


### PR DESCRIPTION
Sending a `POST /api/v2/merch/order/verification` with an invalid payload would cause the backend to throw an error (shown below). I was able to prevent the error from being thrown and receive the correct feedback with the change made in the PR. Please let me know if this was the correct change to make, or if there's an alternate way to resolve the issue being encountered.

```
/Users/steets250/Storage/GitHub/membership-portal/src/error/QueryRunnerAlreadyReleasedError.ts:7
        super();
        ^
QueryRunnerAlreadyReleasedError: Query runner already released. Cannot run queries anymore.
    at new QueryRunnerAlreadyReleasedError (/Users/steets250/Storage/GitHub/membership-portal/src/error/QueryRunnerAlreadyReleasedError.ts:7:9)
    at PostgresQueryRunner.<anonymous> (/Users/steets250/Storage/GitHub/membership-portal/src/driver/postgres/PostgresQueryRunner.ts:202:19)
    at step (/Users/steets250/Storage/GitHub/membership-portal/node_modules/tslib/tslib.js:143:27)
    at Object.next (/Users/steets250/Storage/GitHub/membership-portal/node_modules/tslib/tslib.js:124:57)
    at /Users/steets250/Storage/GitHub/membership-portal/node_modules/tslib/tslib.js:117:75
    at new Promise (<anonymous>)
    at Object.__awaiter (/Users/steets250/Storage/GitHub/membership-portal/node_modules/tslib/tslib.js:113:16)
    at PostgresQueryRunner.query (/Users/steets250/Storage/GitHub/membership-portal/node_modules/typeorm/driver/postgres/PostgresQueryRunner.js:212:24)
    at SelectQueryBuilder.<anonymous> (/Users/steets250/Storage/GitHub/membership-portal/src/query-builder/SelectQueryBuilder.ts:2089:43)
    at step (/Users/steets250/Storage/GitHub/membership-portal/node_modules/tslib/tslib.js:143:27)
[nodemon] app crashed - waiting for file changes before starting...
```