### PR TITLE
Resolve countItemOrders Bug

### DIFF
--- a/services/MerchStoreService.ts
+++ b/services/MerchStoreService.ts
@@ -705,8 +705,11 @@ export default class MerchStoreService {
     }
     const orderedItemOptions = flatten(orders.map((o) => o.items));
     for (let i = 0; i < orderedItemOptions.length; i += 1) {
-      const { item } = itemOptions.get(orderedItemOptions[i].option.uuid);
-      if (counts.has(item)) counts.set(item, counts.get(item) + 1);
+      const orderedOption = itemOptions.get(orderedItemOptions[i].option.uuid);
+      if (orderedOption) {
+        const { item } = orderedOption;
+        if (counts.has(item)) counts.set(item, counts.get(item) + 1);
+      }
     }
     return counts;
   }

--- a/tests/Seeds.ts
+++ b/tests/Seeds.ts
@@ -63,6 +63,7 @@ async function seed(): Promise<void> {
     accessType: UserAccessType.STANDARD,
     firstName: 'Paul',
     lastName: 'Pan',
+    points: 800,
     graduationYear: getGraduationYear(3),
   });
   const MEMBER_JUNIOR = UserFactory.fake({


### PR DESCRIPTION
The `countItemOrders` function made the assumption that the call `itemOptions.get(orderedItemOptions[i].option.uuid)` would always succeed and could be unwrapped to access the response's item property. However, this call returns false when an item that has previously been ordered isn't present in the current order's list of items. I added a check to see if the previously ordered item is present in the order being verified. If so, the count should be incremented. If not, we don't care, since we're only checking monthly/lifetime limits on the pending order.

I additionally increased the `jpan@ucsd.edu` testing account starting points, so that it wouldn't have a negative credit balance.

Resolves #240.