### PR TITLE
Adds ability for users to change their email

### DIFF
--- a/api/controllers/AuthController.ts
+++ b/api/controllers/AuthController.ts
@@ -7,7 +7,7 @@ import {
   SendPasswordResetEmailResponse,
   VerifyEmailResponse,
   ResendEmailVerificationResponse,
-  ModifyEmailResponse,
+  EmailModificationResponse,
 } from 'types';
 import UserAccountService from '../../services/UserAccountService';
 import UserAuthService from '../../services/UserAuthService';
@@ -18,7 +18,7 @@ import {
   LoginRequest,
   RegistrationRequest,
   PasswordResetRequest,
-  ModifyEmailRequest,
+  EmailModificationRequest,
 } from '../validators/AuthControllerRequests';
 import { authActionMetadata } from '../../utils/AuthActionMetadata';
 import { OptionalUserAuthentication, UserAuthentication } from '../middleware/UserAuthentication';
@@ -72,11 +72,11 @@ export class AuthController {
   }
 
   @UseBefore(UserAuthentication)
-  @Post('/modifyEmail')
-  async modifyEmail(@Body() modifyEmailRequest: ModifyEmailRequest,
-    @AuthenticatedUser() user: UserModel): Promise<ModifyEmailResponse> {
-    await this.userAuthService.modifyEmail(user, modifyEmailRequest.email);
-    await this.emailService.sendEmailVerification(user.email, user.firstName, user.accessCode);
+  @Post('/emailModification')
+  async emailModification(@Body() emailModificationRequest: EmailModificationRequest,
+    @AuthenticatedUser() user: UserModel): Promise<EmailModificationResponse> {
+    const updatedUser = await this.userAuthService.modifyEmail(user, emailModificationRequest.email);
+    await this.emailService.sendEmailVerification(updatedUser.email, updatedUser.firstName, updatedUser.accessCode);
     return { error: null };
   }
 

--- a/api/controllers/AuthController.ts
+++ b/api/controllers/AuthController.ts
@@ -73,7 +73,7 @@ export class AuthController {
 
   @UseBefore(UserAuthentication)
   @Post('/emailModification')
-  async emailModification(@Body() emailModificationRequest: EmailModificationRequest,
+  async modifyEmail(@Body() emailModificationRequest: EmailModificationRequest,
     @AuthenticatedUser() user: UserModel): Promise<EmailModificationResponse> {
     const updatedUser = await this.userAuthService.modifyEmail(user, emailModificationRequest.email);
     await this.emailService.sendEmailVerification(updatedUser.email, updatedUser.firstName, updatedUser.accessCode);

--- a/api/validators/AuthControllerRequests.ts
+++ b/api/validators/AuthControllerRequests.ts
@@ -9,6 +9,7 @@ import {
   PasswordResetRequest as IPasswordResetRequest,
   UserRegistration as IUserRegistration,
   PasswordChange as IPasswordChange,
+  ModifyEmailRequest as IModifyEmailRequest,
 } from '../../types';
 
 export class UserRegistration implements IUserRegistration {
@@ -60,6 +61,11 @@ export class LoginRequest implements ILoginRequest {
 
   @IsDefined()
   password: string;
+}
+
+export class ModifyEmailRequest implements IModifyEmailRequest {
+  @IsEmail()
+  email: string;
 }
 
 export class PasswordResetRequest implements IPasswordResetRequest {

--- a/api/validators/AuthControllerRequests.ts
+++ b/api/validators/AuthControllerRequests.ts
@@ -9,7 +9,7 @@ import {
   PasswordResetRequest as IPasswordResetRequest,
   UserRegistration as IUserRegistration,
   PasswordChange as IPasswordChange,
-  ModifyEmailRequest as IModifyEmailRequest,
+  EmailModificationRequest as IEmailModificationRequest,
 } from '../../types';
 
 export class UserRegistration implements IUserRegistration {
@@ -63,7 +63,7 @@ export class LoginRequest implements ILoginRequest {
   password: string;
 }
 
-export class ModifyEmailRequest implements IModifyEmailRequest {
+export class EmailModificationRequest implements IEmailModificationRequest {
   @IsEmail()
   email: string;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@acmucsd/membership-portal",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acmucsd/membership-portal",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "REST API for ACM UCSD's membership portal.",
   "main": "index.d.ts",
   "files": [

--- a/services/UserAuthService.ts
+++ b/services/UserAuthService.ts
@@ -42,6 +42,19 @@ export default class UserAuthService {
     });
   }
 
+  public async modifyEmail(user: UserModel, proposedEmail: string): Promise<void> {
+    return this.transactions.readWrite(async (txn) => {
+      const userRepository = Repositories.user(txn);
+
+      await userRepository.upsertUser(user, {
+        email: proposedEmail,
+        state: UserState.PENDING,
+      });
+
+      await this.setAccessCode(proposedEmail);
+    });
+  }
+
   public async checkAuthToken(authHeader: string): Promise<UserModel> {
     const token = jwt.verify(UserAuthService.parseAuthHeader(authHeader), Config.auth.secret);
     if (!UserAuthService.isAuthToken(token)) throw new BadRequestError('Invalid auth token');

--- a/services/UserAuthService.ts
+++ b/services/UserAuthService.ts
@@ -48,11 +48,8 @@ export default class UserAuthService {
 
       proposedEmail = proposedEmail.toLowerCase();
 
-      // ensure that the proposed email isn't used already
-      const foundUser = await userRepository.findByEmail(proposedEmail);
-      if (foundUser !== undefined) {
-        throw new BadRequestError('Email already in use');
-      }
+      const emailAlreadyUsed = !!(await userRepository.findByEmail(proposedEmail));
+      if (emailAlreadyUsed) throw new BadRequestError('Email already in use');
 
       return userRepository.upsertUser(user, {
         email: proposedEmail,

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -255,7 +255,7 @@ describe('email modification', () => {
     expect(member.state).toEqual(UserState.ACTIVE);
   });
 
-  test('user cannot change email to new email', async () => {
+  test('user cannot change email to an already existing email', async () => {
     const conn = await DatabaseConnection.get();
     let member = UserFactory.fake();
     const otherMember = UserFactory.fake({ email: 'anotheremail@acmucsd.org' });

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -241,7 +241,7 @@ describe('email modification', () => {
 
     when(emailService.sendEmailVerification(request.email, member.firstName, anyString()))
       .thenResolve();
-    const response = await authController.emailModification(request, member);
+    const response = await authController.modifyEmail(request, member);
     expect(response.error).toBeNull();
 
     member = await conn.manager.findOne(UserModel, { uuid: member.uuid });
@@ -271,7 +271,7 @@ describe('email modification', () => {
     const request = { email: otherMember.email };
 
     verify(emailService.sendEmailVerification(request.email, member.firstName, anyString())).never();
-    await expect(authController.emailModification(request, member))
+    await expect(authController.modifyEmail(request, member))
       .rejects.toThrow('Email already in use');
 
     member = await conn.manager.findOne(UserModel, { uuid: member.uuid });

--- a/types/ApiRequests.ts
+++ b/types/ApiRequests.ts
@@ -33,6 +33,10 @@ export interface UserRegistration {
   major: string;
 }
 
+export interface ModifyEmailRequest {
+  email: string
+}
+
 export interface RegistrationRequest {
   user: UserRegistration;
 }

--- a/types/ApiRequests.ts
+++ b/types/ApiRequests.ts
@@ -33,7 +33,7 @@ export interface UserRegistration {
   major: string;
 }
 
-export interface ModifyEmailRequest {
+export interface EmailModificationRequest {
   email: string
 }
 

--- a/types/ApiResponses.ts
+++ b/types/ApiResponses.ts
@@ -71,6 +71,8 @@ export interface ResendEmailVerificationResponse extends ApiResponse {}
 
 export interface VerifyEmailResponse extends ApiResponse {}
 
+export interface ModifyEmailResponse extends ApiResponse {}
+
 export interface SendPasswordResetEmailResponse extends ApiResponse {}
 
 export interface ResetPasswordResponse extends ApiResponse {}

--- a/types/ApiResponses.ts
+++ b/types/ApiResponses.ts
@@ -71,7 +71,7 @@ export interface ResendEmailVerificationResponse extends ApiResponse {}
 
 export interface VerifyEmailResponse extends ApiResponse {}
 
-export interface ModifyEmailResponse extends ApiResponse {}
+export interface EmailModificationResponse extends ApiResponse {}
 
 export interface SendPasswordResetEmailResponse extends ApiResponse {}
 


### PR DESCRIPTION
Closes #229 - needed since store will be requiring all users to have a ucsd email address to use the store, and we anticipate that users will need to change their email.

Adds new route:

- **POST** `/auth/modifyEmail`
    - Request Body:
        - basic authorization stuff
        - ``` { email: string } ```
    - Response Body:
        - errors 
            - usual 'couldn't find email jazz / couldn't send confirmation email jazz'

Note - in #229 i describe a case where this route might be problematic - worth reading that issue before reviewing this PR
      
