### PR TITLE
Add PublicOrderWithItems type to API

### DIFF
--- a/api/controllers/MerchStoreController.ts
+++ b/api/controllers/MerchStoreController.ts
@@ -188,7 +188,7 @@ export class MerchStoreController {
     if (!PermissionsService.canAccessMerchStore(user)) throw new ForbiddenError();
     const order = await this.merchStoreService.findOrderByUuid(params.uuid);
     if (!PermissionsService.canSeeMerchOrder(user, order)) throw new NotFoundError();
-    return { error: null, order: order.getPublicOrder() };
+    return { error: null, order: order.getPublicOrderWithItems() };
   }
 
   @Get('/orders')
@@ -209,7 +209,7 @@ export class MerchStoreController {
     @AuthenticatedUser() user: UserModel): Promise<PlaceMerchOrderResponse> {
     const originalOrder = this.validateMerchOrderRequest(placeOrderRequest.order);
     const order = await this.merchStoreService.placeOrder(originalOrder, user, placeOrderRequest.pickupEvent);
-    return { error: null, order };
+    return { error: null, order: order.getPublicOrderWithItems() };
   }
 
   @Post('/order/verification')

--- a/models/MerchandiseItemOptionModel.ts
+++ b/models/MerchandiseItemOptionModel.ts
@@ -62,7 +62,7 @@ export class MerchandiseItemOptionModel extends BaseEntity {
       price: this.price,
       discountPercentage: this.discountPercentage,
       metadata: this.metadata,
-      item: this.item.getPublicOrderMerchItem(),
+      item: this.item?.getPublicOrderMerchItem(),
     };
   }
 }

--- a/models/OrderModel.ts
+++ b/models/OrderModel.ts
@@ -8,7 +8,7 @@ import {
   ManyToOne,
   JoinColumn,
 } from 'typeorm';
-import { Uuid, PublicOrder, OrderStatus } from '../types';
+import { Uuid, PublicOrder, OrderStatus, PublicOrderWithItems } from '../types';
 import { UserModel } from './UserModel';
 import { OrderItemModel } from './OrderItemModel';
 import { OrderPickupEventModel } from './OrderPickupEventModel';
@@ -52,6 +52,12 @@ export class OrderModel extends BaseEntity {
       status: this.status,
       orderedAt: this.orderedAt,
       pickupEvent: this.pickupEvent?.getPublicOrderPickupEvent(),
+    };
+  }
+
+  public getPublicOrderWithItems(): PublicOrderWithItems {
+    return {
+      ...this.getPublicOrder(),
       items: this.items?.map((oi) => oi.getPublicOrderItem()),
     };
   }

--- a/models/OrderPickupEventModel.ts
+++ b/models/OrderPickupEventModel.ts
@@ -36,7 +36,7 @@ export class OrderPickupEventModel extends BaseEntity {
       orderLimit: this.orderLimit,
     };
 
-    if (canSeeOrders) pickupEvent.orders = this.orders.map((order) => order.getPublicOrder());
+    if (canSeeOrders) pickupEvent.orders = this.orders.map((order) => order.getPublicOrderWithItems());
     return pickupEvent;
   }
 }

--- a/services/MerchStoreService.ts
+++ b/services/MerchStoreService.ts
@@ -9,7 +9,6 @@ import { MerchandiseItemOptionModel } from '../models/MerchandiseItemOptionModel
 import {
   Uuid,
   PublicMerchCollection,
-  PublicOrder,
   ActivityType,
   OrderItemFulfillmentUpdate,
   MerchCollection,
@@ -308,7 +307,7 @@ export default class MerchStoreService {
    */
   public async placeOrder(originalOrder: MerchItemOptionAndQuantity[],
     user: UserModel,
-    pickupEventUuid: Uuid): Promise<PublicOrder> {
+    pickupEventUuid: Uuid): Promise<OrderModel> {
     const [order, merchItemOptions] = await this.transactions.readWrite(async (txn) => {
       const merchItemOptionRepository = Repositories.merchStoreItemOption(txn);
       const itemOptions = await merchItemOptionRepository.batchFindByUuid(originalOrder.map((oi) => oi.option));
@@ -387,7 +386,7 @@ export default class MerchStoreService {
     };
     this.emailService.sendOrderConfirmation(user.email, user.firstName, orderConfirmation);
 
-    return order.getPublicOrder();
+    return order;
   }
 
   private static humanReadableDateString(date: Date): string {

--- a/types/ApiResponses.ts
+++ b/types/ApiResponses.ts
@@ -202,6 +202,9 @@ export interface PublicOrder {
   status: string;
   orderedAt: Date;
   pickupEvent: PublicOrderPickupEvent;
+}
+
+export interface PublicOrderWithItems extends PublicOrder {
   items: PublicOrderItem[];
 }
 
@@ -248,7 +251,7 @@ export interface CreateMerchItemOptionResponse extends ApiResponse {
 export interface DeleteMerchItemOptionResponse extends ApiResponse {}
 
 export interface GetOneMerchOrderResponse extends ApiResponse {
-  order: PublicOrder;
+  order: PublicOrderWithItems;
 }
 
 export interface GetAllMerchOrdersResponse extends ApiResponse {
@@ -256,7 +259,7 @@ export interface GetAllMerchOrdersResponse extends ApiResponse {
 }
 
 export interface PlaceMerchOrderResponse extends ApiResponse {
-  order: PublicOrder;
+  order: PublicOrderWithItems;
 }
 
 export interface VerifyMerchOrderResponse extends ApiResponse {}
@@ -344,7 +347,7 @@ export interface PublicOrderPickupEvent {
   start: Date;
   end: Date;
   description: string;
-  orders?: PublicOrder[];
+  orders?: PublicOrderWithItems[];
   orderLimit?: number;
 }
 


### PR DESCRIPTION
This change addresses this comment (https://github.com/acmucsd/membership-portal/commit/c1a55fc5961b41f5ba94222aa47ba3d5c457f255#r62577745) about a 500 error being thrown on GET /orders. The error was happening because the `PublicOrder` type assumes the join to OrderItems, MerchItemOptions, and MerchItems have been successfully made, but for the GET /orders route, we aren't doing that join.

Adding a `PublicOrderWithItems` type that assumes this join, and removing this assumption from the existing `PublicOrder` type (by removing the `items` field) allows GET /orders to not need that join (by using the `PublicOrder` type), while allowing other routes to still require that join (by using the `PublicOrderWithItems` type).