### PR TITLE
Modify GET /store/collection to order by creation

### DIFF
--- a/migrations/0032-add-created-at-column-to-merch-collection.ts
+++ b/migrations/0032-add-created-at-column-to-merch-collection.ts
@@ -1,10 +1,8 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddCreatedAtColumnToMerchCollection1640851101278 implements MigrationInterface {
-  name = 'AddCreatedAtColumnToMerchCollection1640851101278';
-
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query('ALTER TABLE "MerchandiseCollections" ADD "createdAt" TIMESTAMP NOT NULL DEFAULT now()');
+    await queryRunner.query('ALTER TABLE "MerchandiseCollections" ADD "createdAt" TIMESTAMPTZ NOT NULL DEFAULT now()');
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/migrations/0032-add-created-at-column-to-merch-collection.ts
+++ b/migrations/0032-add-created-at-column-to-merch-collection.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCreatedAtColumnToMerchCollection1640851101278 implements MigrationInterface {
+  name = 'AddCreatedAtColumnToMerchCollection1640851101278';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "MerchandiseCollections" ADD "createdAt" TIMESTAMP NOT NULL DEFAULT now()');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE "MerchandiseCollections" DROP COLUMN "createdAt"');
+  }
+}

--- a/models/MerchandiseCollectionModel.ts
+++ b/models/MerchandiseCollectionModel.ts
@@ -10,7 +10,7 @@ export class MerchandiseCollectionModel extends BaseEntity {
   @Column('varchar', { length: 255 })
   title: string;
 
-  @CreateDateColumn()
+  @CreateDateColumn({ type: 'timestamptz' })
   createdAt: Date;
 
   @Column('varchar', { length: 255 })

--- a/models/MerchandiseCollectionModel.ts
+++ b/models/MerchandiseCollectionModel.ts
@@ -1,4 +1,4 @@
-import { Entity, BaseEntity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
+import { Entity, BaseEntity, Column, PrimaryGeneratedColumn, OneToMany, CreateDateColumn } from 'typeorm';
 import { Uuid, PublicMerchCollection } from '../types';
 import { MerchandiseItemModel } from './MerchandiseItemModel';
 
@@ -9,6 +9,9 @@ export class MerchandiseCollectionModel extends BaseEntity {
 
   @Column('varchar', { length: 255 })
   title: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
 
   @Column('varchar', { length: 255 })
   themeColorHex: string;
@@ -28,6 +31,7 @@ export class MerchandiseCollectionModel extends BaseEntity {
       title: this.title,
       themeColorHex: this.themeColorHex,
       description: this.description,
+      createdAt: this.createdAt,
     };
     if (this.items) baseMerchCollection.items = this.items.map((i) => i.getPublicMerchItem());
     return baseMerchCollection;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@acmucsd/membership-portal",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acmucsd/membership-portal",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "REST API for ACM UCSD's membership portal.",
   "main": "index.d.ts",
   "files": [

--- a/repositories/MerchStoreRepository.ts
+++ b/repositories/MerchStoreRepository.ts
@@ -28,6 +28,7 @@ export class MerchCollectionRepository extends BaseRepository<MerchandiseCollect
       .leftJoinAndSelect('collection.items', 'items')
       .leftJoinAndSelect('items.options', 'options')
       .where({ archived: false })
+      .orderBy('collection.createdAt', 'DESC')
       .getMany();
   }
 

--- a/repositories/MerchStoreRepository.ts
+++ b/repositories/MerchStoreRepository.ts
@@ -19,6 +19,7 @@ export class MerchCollectionRepository extends BaseRepository<MerchandiseCollect
     return this.repository.createQueryBuilder('collection')
       .leftJoinAndSelect('collection.items', 'items')
       .leftJoinAndSelect('items.options', 'options')
+      .orderBy('collection.createdAt', 'DESC')
       .getMany();
   }
 

--- a/tests/data/MerchFactory.ts
+++ b/tests/data/MerchFactory.ts
@@ -15,6 +15,7 @@ export class MerchFactory {
       title: faker.datatype.hexaDecimal(10),
       description: faker.lorem.sentences(2),
       themeColorHex: faker.internet.color(),
+      createdAt: faker.date.recent(),
     });
 
     // merging arrays returns a union of fake.items and substitute.items, so only create

--- a/tests/merchStore.test.ts
+++ b/tests/merchStore.test.ts
@@ -18,7 +18,26 @@ afterAll(async () => {
   await DatabaseConnection.clear();
   await DatabaseConnection.close();
 });
+describe('creating merch collections', () => {
+  test('getting created collections returns them in reverse order of creation', async () => {
+    const conn = await DatabaseConnection.get();
+    const admin = UserFactory.fake({ accessType: UserAccessType.ADMIN });
+    const member = UserFactory.fake({ accessType: UserAccessType.STANDARD });
+    const firstCollectionToBeMade = MerchFactory.fakeCollection();
+    const secondCollectionToBeMade = MerchFactory.fakeCollection();
 
+    await new PortalState()
+      .createUsers(admin, member)
+      .createMerchCollections(firstCollectionToBeMade, secondCollectionToBeMade)
+      .write();
+
+    const merchStoreController = ControllerFactory.merchStore(conn);
+
+    const collections = await merchStoreController.getAllMerchCollections(admin);
+    expect(collections.collections.map((collection) => collection.uuid))
+      .toEqual([secondCollectionToBeMade, firstCollectionToBeMade].map((collection) => collection.uuid));
+  });
+});
 describe('editing merch collections', () => {
   test('only admins can edit merch collections', async () => {
     const conn = await DatabaseConnection.get();

--- a/types/ApiResponses.ts
+++ b/types/ApiResponses.ts
@@ -143,6 +143,7 @@ export interface PublicMerchCollection {
   themeColorHex?: string;
   description: string;
   items: PublicMerchItem[];
+  createdAt: Date;
 }
 
 export interface PublicMerchItem {


### PR DESCRIPTION
Closes #239.

Key Changes
- Adds a `createdAt` column to the `MerchandiseCollectionModel` (is there any reason we're not doing this by default?)
- Makes it so `getAllActiveCollections` and `getAllCollections` sort by the `createdAt` field in `DESC`

Note
- test naming is not my strong suit