### PR TITLE
Add user join for GET /order/pickup/future and /past routes

### DIFF
--- a/models/OrderModel.ts
+++ b/models/OrderModel.ts
@@ -47,7 +47,7 @@ export class OrderModel extends BaseEntity {
   public getPublicOrder(): PublicOrder {
     return {
       uuid: this.uuid,
-      user: this.user?.getPublicProfile(),
+      user: this.user.getPublicProfile(),
       totalCost: this.totalCost,
       status: this.status,
       orderedAt: this.orderedAt,

--- a/models/OrderModel.ts
+++ b/models/OrderModel.ts
@@ -47,7 +47,7 @@ export class OrderModel extends BaseEntity {
   public getPublicOrder(): PublicOrder {
     return {
       uuid: this.uuid,
-      user: this.user.getPublicProfile(),
+      user: this.user?.getPublicProfile(),
       totalCost: this.totalCost,
       status: this.status,
       orderedAt: this.orderedAt,

--- a/repositories/MerchOrderRepository.ts
+++ b/repositories/MerchOrderRepository.ts
@@ -154,6 +154,7 @@ export class OrderPickupEventRepository extends BaseRepository<OrderPickupEventM
   private getBaseFindManyQuery(): SelectQueryBuilder<OrderPickupEventModel> {
     return this.repository
       .createQueryBuilder('orderPickupEvent')
-      .leftJoinAndSelect('orderPickupEvent.orders', 'order');
+      .leftJoinAndSelect('orderPickupEvent.orders', 'order')
+      .leftJoinAndSelect('order.user', 'user');
   }
 }


### PR DESCRIPTION
There was a bug when a user was attempting to fetch their own order, in which `this.user` is null in the `OrderModel`, and an error is thrown. I removed the assumption of the user property being defined and it is working as expected. Let me know if this isn't the right remedy for the issue.

Here's the error printout:
```
TypeError: Cannot read properties of undefined (reading 'getPublicProfile')
    at OrderModel.getPublicOrder (/Users/steets250/Storage/GitHub/membership-portal/models/OrderModel.ts:50:23)
    at OrderModel.getPublicOrderWithItems (/Users/steets250/Storage/GitHub/membership-portal/models/OrderModel.ts:60:15)
    at /Users/steets250/Storage/GitHub/membership-portal/models/OrderPickupEventModel.ts:39:77
    at Array.map (<anonymous>)
    at OrderPickupEventModel.getPublicOrderPickupEvent (/Users/steets250/Storage/GitHub/membership-portal/models/OrderPickupEventModel.ts:39:56)
    at /Users/steets250/Storage/GitHub/membership-portal/api/controllers/MerchStoreController.ts:286:8
    at Array.map (<anonymous>)
    at MerchStoreController.<anonymous> (/Users/steets250/Storage/GitHub/membership-portal/api/controllers/MerchStoreController.ts:285:45)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/steets250/Storage/GitHub/membership-portal/api/controllers/MerchStoreController.ts:17:58)
```