### PR TITLE
Allow decrementation of option quantities

### DIFF
--- a/api/validators/MerchStoreRequests.ts
+++ b/api/validators/MerchStoreRequests.ts
@@ -9,6 +9,7 @@ import {
   IsHexColor,
   IsDateString,
   ArrayNotEmpty,
+  IsNumber,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import {
@@ -110,7 +111,9 @@ export class MerchItemOptionEdit implements IMerchItemOptionEdit {
   @IsUUID()
   uuid: string;
 
-  @Min(0)
+  /** We allow negative quantityToAdd for decrementing an option's quantity
+   * (e.g. if the initial quantity was typoed) */
+  @IsNumber()
   quantityToAdd?: number;
 
   @Min(0)

--- a/services/MerchStoreService.ts
+++ b/services/MerchStoreService.ts
@@ -191,8 +191,13 @@ export default class MerchStoreService {
           const optionUpdate = optionUpdatesByUuid.get(currentOption.uuid);
           // 'quantity' is incremented instead of directly set to avoid concurrency issues with orders
           // e.g. there's 10 of an item and someone adds 5 to stock while someone else orders 1
-          // so the merch store admin sets quantity to 15 but the true quantity is 14
-          if (optionUpdate.quantityToAdd) currentOption.quantity += optionUpdate.quantityToAdd;
+          // so the merch store admin sets quantity to 15 but the true quantity is 14.
+          if (optionUpdate.quantityToAdd) {
+            currentOption.quantity += optionUpdate.quantityToAdd;
+            if (currentOption.quantity < 0) {
+              throw new UserError(`Cannot decrement option quantity below 0 for option: ${currentOption.uuid}`);
+            }
+          }
           return MerchandiseItemOptionModel.merge(currentOption, optionUpdate);
         });
       }

--- a/tests/merchStore.test.ts
+++ b/tests/merchStore.test.ts
@@ -280,7 +280,7 @@ describe('merch items with no options', () => {
 });
 
 describe('merch item edits', () => {
-  test('succeeds when item fields are updated', async () => {
+  test('merch item fields can be updated', async () => {
     const conn = await DatabaseConnection.get();
     const admin = UserFactory.fake({ accessType: UserAccessType.ADMIN });
     const item = MerchFactory.fakeItem();
@@ -308,7 +308,7 @@ describe('merch item edits', () => {
     expect(getMerchItemResponse.item.lifetimeLimit).toEqual(merchItemEdits.lifetimeLimit);
   });
 
-  test('succeeds when item option fields are updated', async () => {
+  test('merch item option fields can be updated', async () => {
     const conn = await DatabaseConnection.get();
     const admin = UserFactory.fake({ accessType: UserAccessType.ADMIN });
     const item = MerchFactory.fakeItem({ hasVariantsEnabled: true });
@@ -346,7 +346,7 @@ describe('merch item edits', () => {
       .toEqual(expect.arrayContaining(updatedOptions));
   });
 
-  test('fails when updated options have multiple types', async () => {
+  test('items cannot be updated to have multiple options with different types', async () => {
     const conn = await DatabaseConnection.get();
     const admin = UserFactory.fake({ accessType: UserAccessType.ADMIN });
     const item = MerchFactory.fakeItem({ hasVariantsEnabled: true });
@@ -365,7 +365,7 @@ describe('merch item edits', () => {
       .rejects.toThrow('Merch items cannot have multiple option types');
   });
 
-  test('succeeds when updated options have same type', async () => {
+  test('items can have their options\' types updated as long as its the same type for all options', async () => {
     const conn = await DatabaseConnection.get();
     const admin = UserFactory.fake({ accessType: UserAccessType.ADMIN });
     const item = MerchFactory.fakeItem({ hasVariantsEnabled: true });
@@ -399,7 +399,7 @@ describe('merch item edits', () => {
 });
 
 describe('merch item option variants', () => {
-  test('fails when disabling variants on item with multiple options', async () => {
+  test('items cannot have variants disabled and have multiple options', async () => {
     const conn = await DatabaseConnection.get();
     const admin = UserFactory.fake({ accessType: UserAccessType.ADMIN });
     const item = MerchFactory.fakeItem({ hasVariantsEnabled: true });
@@ -415,7 +415,7 @@ describe('merch item option variants', () => {
       .rejects.toThrow('Merch items with variants disabled cannot have multiple options');
   });
 
-  test('fails when enabling variants on item where only option has null metadata', async () => {
+  test('items cannot have variants enabled and have null metadata for an option', async () => {
     const conn = await DatabaseConnection.get();
     const admin = UserFactory.fake({ accessType: UserAccessType.ADMIN });
     const item = MerchFactory.fakeItem({ hasVariantsEnabled: false });


### PR DESCRIPTION
Allows merch item option quantities to be decremented in addition to being incremented, in the event that the original quantity specified was typo'd, or if a set number of option stock needs to be set aside for some other event.

The one potential issue that could theoretically arise is if a member is at cart checkout after adding items to their cart, then an item's option gets decremented to below the quantity requested by the member, and then the member places their order - this will result in the order placement failing. However, even without this change, this case can still happen if other members also order that option before the first member places their order, so the addition of this change shouldn't cause any additional issues in the system. Plus, the only time decrementation would be used is for typo-fixing or for special cases in which stock needs to be reduced, so it is quite rare that this feature would be used in the first place, let alone being used concurrently with someone placing an order.