### PR TITLE
Add Monthly/Lifetime Limits to Item Edit Validator

### DIFF
--- a/api/validators/MerchStoreRequests.ts
+++ b/api/validators/MerchStoreRequests.ts
@@ -182,6 +182,12 @@ export class MerchItemEdit implements IMerchItemEdit {
   @Allow()
   hidden?: boolean;
 
+  @Min(0)
+  monthlyLimit?: number;
+
+  @Min(0)
+  lifetimeLimit?: number;
+
   @Allow()
   hasVariantsEnabled?: boolean;
 


### PR DESCRIPTION
`monthlyLimit` and `lifetimeLimit` were missing from the `MerchStoreRequests` validator, so I added those in and that fixed the issue.

Closes #257.
