### PR TITLE
Allow users with admin role to be displayed on leaderboard, except for acm@ucsd.edu

### DIFF
--- a/repositories/LeaderboardRepository.ts
+++ b/repositories/LeaderboardRepository.ts
@@ -1,8 +1,9 @@
 import { EntityRepository, Not, Raw } from 'typeorm';
 import * as moment from 'moment';
+import { Config } from 'config';
 import { ActivityModel } from '../models/ActivityModel';
 import { UserModel } from '../models/UserModel';
-import { UserAccessType, UserState } from '../types';
+import { UserState } from '../types';
 import { BaseRepository } from './BaseRepository';
 
 @EntityRepository(UserModel)
@@ -12,7 +13,7 @@ export class LeaderboardRepository extends BaseRepository<UserModel> {
       skip: offset,
       take: limit,
       where: {
-        accessType: Not(UserAccessType.ADMIN),
+        email: Not(Config.admin.email),
         state: Raw((state) => `NOT ${state} = '${UserState.BLOCKED}' AND NOT ${state} = '${UserState.PENDING}'`),
       },
       order: { points: 'DESC' },
@@ -38,7 +39,7 @@ export class LeaderboardRepository extends BaseRepository<UserModel> {
         'usr.uuid = totals.user',
       )
       .setParameter('from', new Date(from))
-      .where(`NOT "accessType" = '${UserAccessType.ADMIN}'`)
+      .where(`NOT "email" = '${Config.admin.email}'`)
       .andWhere(`NOT state = '${UserState.BLOCKED}'`)
       .andWhere(`NOT state = '${UserState.PENDING}'`)
       .orderBy('points', 'DESC')
@@ -68,7 +69,7 @@ export class LeaderboardRepository extends BaseRepository<UserModel> {
       )
       .setParameter('from', new Date(from))
       .setParameter('to', new Date(to))
-      .where(`NOT "accessType" = '${UserAccessType.ADMIN}'`)
+      .where(`NOT "email" = '${Config.admin.email}'`)
       .andWhere(`NOT state = '${UserState.BLOCKED}'`)
       .andWhere(`NOT state = '${UserState.PENDING}'`)
       .orderBy('points', 'DESC')

--- a/repositories/LeaderboardRepository.ts
+++ b/repositories/LeaderboardRepository.ts
@@ -1,6 +1,6 @@
 import { EntityRepository, Not, Raw } from 'typeorm';
 import * as moment from 'moment';
-import { Config } from 'config';
+import { Config } from '../config';
 import { ActivityModel } from '../models/ActivityModel';
 import { UserModel } from '../models/UserModel';
 import { UserState } from '../types';


### PR DESCRIPTION
Since some users have ADMIN access types now, they weren't getting displayed on the leaderboard since we don't return any ADMIN accounts to the client in our leaderboard call. The intended behavior should be to only restrict the acm@ucsd.edu admin account
