### PR TITLE
Set minimum quantity to 1 for fake options

### DIFF
--- a/tests/data/MerchFactory.ts
+++ b/tests/data/MerchFactory.ts
@@ -57,7 +57,7 @@ export class MerchFactory {
   public static fakeOption(substitute?: Partial<MerchandiseItemOptionModel>): MerchandiseItemOptionModel {
     const fake = MerchandiseItemOptionModel.create({
       uuid: uuid(),
-      quantity: FactoryUtils.getRandomNumber(0, 25),
+      quantity: FactoryUtils.getRandomNumber(1, 25),
       price: MerchFactory.randomPrice(),
       discountPercentage: MerchFactory.randomDiscountPercentage(),
       metadata: null,


### PR DESCRIPTION
Currently, the MerchFactory allows for quantity = 0 to be set for an option. This means that, nondeterministically, some tests can fail because when they don't specify a quantity for an option, there is a chance it can equal 0, so when an order is attempted to be placed, an error will be thrown in the test because the item is out of stock.

This PR bumps the minimum quantity to 1 so that any option can be ordered from at least once without having to manually specify the quantity