### PR TITLE
Fix monthly/lifetime limit counting bug

### DIFF
--- a/repositories/MerchOrderRepository.ts
+++ b/repositories/MerchOrderRepository.ts
@@ -40,10 +40,26 @@ export class MerchOrderRepository extends BaseRepository<OrderModel> {
   }
 
   /**
-   * Gets all orders for a given user. Returns the order joined with its pickup event.
+   * Gets all orders for a given user. Returns the order joined with its pickup event and user.
    */
   public async getAllOrdersForUser(user: UserModel): Promise<OrderModel[]> {
     return this.repository.find({ user });
+  }
+
+  /**
+   * Gets all orders for a given user. Returns the order joined with its pickup event, user,
+   * merch item options, and merch items.
+   */
+  public async getAllOrdersWithItemsForUser(user: UserModel): Promise<OrderModel[]> {
+    return this.repository
+      .createQueryBuilder('order')
+      .leftJoinAndSelect('order.pickupEvent', 'orderPickupEvent')
+      .leftJoinAndSelect('order.items', 'orderItem')
+      .leftJoinAndSelect('order.user', 'user')
+      .leftJoinAndSelect('orderItem.option', 'option')
+      .leftJoinAndSelect('option.item', 'merchItem')
+      .where('order.user = :uuid', { uuid: user.uuid })
+      .getMany();
   }
 
   public async upsertMerchOrder(order: OrderModel, changes?: Partial<OrderModel>): Promise<OrderModel> {


### PR DESCRIPTION
Closes #269 

There was a bug where a user could order different options of an item to bypass the monthly/lifetime limits set for that item. This bug was due to a logical bug in the counting of previous items ordered (in `MerchStoreService::countItemOrders`), where the count would only increment if an option wanting to be ordered now was previously ordered before. 

I've modified the logic of the method to increment counts for every item ordered rather than for only items whose specific options are being ordered now.
