### PR TITLE
Update Undefined Check

### DIFF
--- a/templates/itemDisplay.ejs
+++ b/templates/itemDisplay.ejs
@@ -9,7 +9,7 @@
             <div style="border-bottom: 1px solid #e6e6e6; height: 1px; margin: 16px -16px;"></div>
         <% } %>
     <% } %>
-    <% if (totalCost) { %>
+    <% if (typeof totalCost !== 'undefined') { %>
         <div style="border-bottom: 1px solid #e6e6e6; height: 1px; margin: 16px -16px;"></div>
         <span style="font-size: 24px; vertical-align: middle;">Total:</span>
         <span style="font-size: 18px; vertical-align: middle;"><%= totalCost %></span>


### PR DESCRIPTION
Apparently checking `if (varName)` isn't enough to prevent undefined from breaking `.ejs` templates. The correct way is `if (typeof varName !== 'undefined')`. This error was causing partial fulfillment emails to not send. This also brought up the point that we're not currently verifying that `.ejs` templates succeed, and I opened #275 regarding that.