### PR TITLE
Update isUnfulfilled Order

### DIFF
--- a/services/MerchStoreService.ts
+++ b/services/MerchStoreService.ts
@@ -993,7 +993,9 @@ export default class MerchStoreService {
   }
 
   private isUnfulfilledOrder(order: OrderModel): boolean {
-    return order.status !== OrderStatus.FULFILLED && order.status !== OrderStatus.PARTIALLY_FULFILLED;
+    return order.status !== OrderStatus.FULFILLED
+    && order.status !== OrderStatus.PARTIALLY_FULFILLED
+    && order.status !== OrderStatus.CANCELLED;
   }
 
   public async getCartItems(options: string[]): Promise<MerchandiseItemOptionModel[]> {

--- a/tests/merchOrder.test.ts
+++ b/tests/merchOrder.test.ts
@@ -1078,8 +1078,8 @@ describe('merch order pickup events', () => {
     // update the pickup event to have passed
     const pickupEventUuid = { uuid: pickupEvent.uuid };
     const pickupEventUpdates = {
-      start: moment().subtract(3, 'hours').toDate(),
-      end: moment().subtract(2, 'hours').toDate(),
+      start: moment().startOf('day').toDate(),
+      end: moment().startOf('day').add(2, 'hours').toDate(),
     };
     await conn.manager.update(OrderPickupEventModel, pickupEventUuid, pickupEventUpdates);
 
@@ -1123,8 +1123,8 @@ describe('merch order pickup events', () => {
     const cancelledPickupEventUuid = { uuid: pickupEventToCancel.uuid };
     const completedPickupEventUuid = { uuid: pickupEventToComplete.uuid };
     const pickupEventUpdates = {
-      start: moment().subtract(3, 'hours').toDate(),
-      end: moment().subtract(2, 'hours').toDate(),
+      start: moment().startOf('day').toDate(),
+      end: moment().startOf('day').add(2, 'hours').toDate(),
     };
     await conn.manager.update(OrderPickupEventModel, cancelledPickupEventUuid, pickupEventUpdates);
     await conn.manager.update(OrderPickupEventModel, completedPickupEventUuid, pickupEventUpdates);
@@ -1241,8 +1241,8 @@ describe('merch order pickup events', () => {
     // update the pickup event to have passed
     const pickupEventUuid = { uuid: pickupEvent.uuid };
     const pickupEventUpdates = {
-      start: moment().subtract(3, 'hours').toDate(),
-      end: moment().subtract(2, 'hours').toDate(),
+      start: moment().startOf('day').toDate(),
+      end: moment().startOf('day').add(2, 'hours').toDate(),
     };
     await conn.manager.update(OrderPickupEventModel, pickupEventUuid, pickupEventUpdates);
 


### PR DESCRIPTION
When completing a pickup event, it was marking all unfulfilled orders as missed. However, cancelled orders were also covered by the criteria to update unfulfilled orders, so those also got marked as missed.