### PR TITLE
Temporarily remove same-day completion requirement for pickup events

### DIFF
--- a/services/MerchStoreService.ts
+++ b/services/MerchStoreService.ts
@@ -848,7 +848,9 @@ export default class MerchStoreService {
   }
 
   private static isPickupEventHappeningToday(pickupEvent: OrderPickupEventModel): boolean {
-    return moment().isSame(moment(pickupEvent.start), 'day');
+    // return moment().isSame(moment(pickupEvent.start), 'day');
+
+    return true;
   }
 
   public async cancelAllPendingOrders(user: UserModel): Promise<void> {


### PR DESCRIPTION
Allow us to finish the pickup event that happened Jan 24 to correctly send out pickup event missed emails, since there was an issue with events being marked as missed incorrectly.