### PR TITLE
Add Long Census Event

### DIFF
--- a/tests/Seeds.ts
+++ b/tests/Seeds.ts
@@ -298,6 +298,17 @@ async function seed(): Promise<void> {
     attendanceCode: 'f0rk',
     ...staffed,
   });
+  const LONG_ACM_EVENT = EventFactory.fake({
+    title: 'Winter 2022 Census',
+    description: `Fill out our Winter 2022 census at https://acmurl.com/census! We
+    appreciate your input and will continue to take your feedback to improve ACM.
+    After checking in, you will automatically be entered into a raffle for a winter
+    gift set!`,
+    ...general,
+    location: 'Online',
+    ...EventFactory.daysLong(7),
+    attendanceCode: 'c3nsus',
+  });
 
   const MERCH_COLLECTION_1 = MerchFactory.fakeCollection({
     title: 'The Hack School Collection',
@@ -547,6 +558,7 @@ async function seed(): Promise<void> {
       PAST_AI_WORKSHOP_2,
       PAST_ACM_PANEL,
       PAST_ACM_SOCIAL_2,
+      LONG_ACM_EVENT,
     )
     .attendEvents([
       STAFF_AI,

--- a/tests/data/EventFactory.ts
+++ b/tests/data/EventFactory.ts
@@ -61,6 +61,13 @@ export class EventFactory {
     };
   }
 
+  public static daysLong(n: number): Partial<EventModel> {
+    return {
+      start: FactoryUtils.roundToHalfHour(moment().hour(11)),
+      end: FactoryUtils.roundToHalfHour(moment().add(n, 'days').hour(13)),
+    };
+  }
+
   private static randomPointValue(): number {
     // some multiple of 5, min 5 and max 20
     return FactoryUtils.getRandomNumber(5, 20, 5);


### PR DESCRIPTION
This PR adds the `daysLong` static method that returns dates that are `n` days apart, and then uses that method for `LONG_ACM_EVENT`, which is used to test the correct display of multi-day events.

Closes #287.