### PR TITLE
Update return type for getAllEvents

### DIFF
--- a/api/controllers/EventController.ts
+++ b/api/controllers/EventController.ts
@@ -111,10 +111,11 @@ export class EventController {
 
   @UseBefore(OptionalUserAuthentication)
   @Get()
-  async getAllEvents(@QueryParams() options: EventSearchOptions, @AuthenticatedUser() user: UserModel): Promise<GetAllEventsResponse> {
+  async getAllEvents(@QueryParams() options: EventSearchOptions, @AuthenticatedUser() user: UserModel):
+  Promise<GetAllEventsResponse> {
     const canSeeAttendanceCode = !!user && PermissionsService.canEditEvents(user);
     const events = await this.eventService.getAllEvents(canSeeAttendanceCode, options);
-    return { error: null, events: events };
+    return { error: null, events };
   }
 
   @UseBefore(UserAuthentication)

--- a/api/controllers/EventController.ts
+++ b/api/controllers/EventController.ts
@@ -17,6 +17,7 @@ import {
   GetOneEventResponse,
   UpdateEventCoverResponse,
   GetFutureEventsResponse,
+  GetAllEventsResponse,
   GetPastEventsResponse,
 } from '../../types';
 import { UuidParam } from '../validators/GenericRequests';
@@ -110,10 +111,10 @@ export class EventController {
 
   @UseBefore(OptionalUserAuthentication)
   @Get()
-  async getAllEvents(@QueryParams() options: EventSearchOptions, @AuthenticatedUser() user: UserModel) {
+  async getAllEvents(@QueryParams() options: EventSearchOptions, @AuthenticatedUser() user: UserModel): Promise<GetAllEventsResponse> {
     const canSeeAttendanceCode = !!user && PermissionsService.canEditEvents(user);
     const events = await this.eventService.getAllEvents(canSeeAttendanceCode, options);
-    return { error: null, events };
+    return { error: null, events: events };
   }
 
   @UseBefore(UserAuthentication)


### PR DESCRIPTION
Updated return type of `getAllEvents` to utilize the `GetAllEventsResponse` DTO

Responds partly to #288 

Held off on updating the response to `cancelMerchOrder`. There was a discrepancy in the behaviours of `cancelMerchOrder`, `fulfillMerchOrderItems`, and `rescheduleOrderPickup`. I noticed `fulfillMerchOrderItems` returns a `FulfillMerchOrderResponse` DTO and modifies the respective order, but the other two routes do not return anything despite modifying the model. Not sure if this was intended, but may be worth looking into for consistency.