### PR TITLE
Make get single event authentication optional

### DIFF
--- a/api/controllers/EventController.ts
+++ b/api/controllers/EventController.ts
@@ -80,11 +80,11 @@ export class EventController {
     return { error: null };
   }
 
-  @UseBefore(UserAuthentication)
+  @UseBefore(OptionalUserAuthentication)
   @Get('/:uuid')
   async getOneEvent(@Params() params: UuidParam,
     @AuthenticatedUser() user: UserModel): Promise<GetOneEventResponse> {
-    const canSeeAttendanceCode = PermissionsService.canEditEvents(user);
+    const canSeeAttendanceCode = !!user && PermissionsService.canEditEvents(user);
     const event = await this.eventService.findByUuid(params.uuid, canSeeAttendanceCode);
     return { error: null, event };
   }


### PR DESCRIPTION
disclaimer: i know basically nothing about back-end so i'm not sure how to run this code or if anything works. 

i need to use this endpoint on main website to get event data and we don't have any required log-in structure there so i want to remove authentication.

 I tried to model it off of the endpoint for getAllEvents so we can fetch individual events without authentication while still using the authentication if it was provided and necessary for attendance data. hopefully this wont break any existing functionality.

edit: tested locally and everything works