### PR TITLE
Upgrade docker version to fix CircleCI image build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,9 @@ jobs:
       - run:
           name: Push application Docker image
           command: |
-              echo "test"
+            echo "$DOCKER_PASS" | docker login --username $DOCKER_USER --password-stdin
+            docker tag app "acmucsd/membership-portal-api:latest"
+            docker push "acmucsd/membership-portal-api:latest"
   deploy:
     machine:
       enabled: true
@@ -111,7 +113,7 @@ workflows:
             - test
           filters:
             branches:
-              only: docker-upgrade
+              only: master
       - deploy:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,11 +54,12 @@ jobs:
           command: yarn test
   image:
     working_directory: /app
-    - setup_remote_docker:
-        version: 19.03.13
+    docker:
+      - image: docker:20.10.2
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.13
       - restore_cache:
           keys:
             - v1-{{ .Branch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.2
       - restore_cache:
           keys:
             - v1-{{ .Branch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,8 @@ jobs:
           command: yarn test
   image:
     working_directory: /app
-    docker:
-      - image: docker:20.10.2
+    - setup_remote_docker:
+        version: 19.03.13
     steps:
       - checkout
       - setup_remote_docker
@@ -85,9 +85,7 @@ jobs:
       - run:
           name: Push application Docker image
           command: |
-            echo "$DOCKER_PASS" | docker login --username $DOCKER_USER --password-stdin
-            docker tag app "acmucsd/membership-portal-api:latest"
-            docker push "acmucsd/membership-portal-api:latest"
+              echo "test"
   deploy:
     machine:
       enabled: true
@@ -112,7 +110,7 @@ workflows:
             - test
           filters:
             branches:
-              only: master
+              only: docker-upgrade
       - deploy:
           requires:
             - build


### PR DESCRIPTION
Fix: https://github.com/yarnpkg/yarn/issues/8389. We set the docker version to 20 instead of 19 to match our current docker version.