### PR TITLE
Fix states for cancel all orders route

### DIFF
--- a/repositories/MerchOrderRepository.ts
+++ b/repositories/MerchOrderRepository.ts
@@ -1,4 +1,4 @@
-import { EntityRepository, SelectQueryBuilder } from 'typeorm';
+import { EntityRepository, In, SelectQueryBuilder } from 'typeorm';
 import { OrderStatus, Uuid } from '../types';
 import { OrderModel } from '../models/OrderModel';
 import { UserModel } from '../models/UserModel';
@@ -32,9 +32,13 @@ export class MerchOrderRepository extends BaseRepository<OrderModel> {
    * Gets all orders for all users. Returns the order joined with its pickup event.
    * Can optionally filter by order status.
    */
-  public async getAllOrdersForAllUsers(status?: OrderStatus): Promise<OrderModel[]> {
-    if (status) {
-      return this.repository.find({ status });
+  public async getAllOrdersForAllUsers(...statuses: OrderStatus[]): Promise<OrderModel[]> {
+    if (statuses.length > 0) {
+      return this.repository.find({
+        where: {
+          status: In(statuses),
+        },
+      });
     }
     return this.repository.find();
   }


### PR DESCRIPTION
Fixes a bug where the POST /merch/order/cancel route was only cancelling orders that were PLACED, and not orders that could also be PICKUP_MISSED, PICKUP_CANCELLED, PARTIALLY_FULFILLED. Also improves an existing test for this route to make sure all order states properly transition to either the FULFILLED or CANCELLED state with the usage of this route.
