### PR TITLE
Add email template for cancel all orders confirmation

### DIFF
--- a/repositories/MerchOrderRepository.ts
+++ b/repositories/MerchOrderRepository.ts
@@ -1,4 +1,4 @@
-import { EntityRepository, SelectQueryBuilder } from 'typeorm';
+import { EntityRepository, In, SelectQueryBuilder } from 'typeorm';
 import { OrderStatus, Uuid } from '../types';
 import { OrderModel } from '../models/OrderModel';
 import { UserModel } from '../models/UserModel';
@@ -32,9 +32,13 @@ export class MerchOrderRepository extends BaseRepository<OrderModel> {
    * Gets all orders for all users. Returns the order joined with its pickup event.
    * Can optionally filter by order status.
    */
-  public async getAllOrdersForAllUsers(status?: OrderStatus): Promise<OrderModel[]> {
-    if (status) {
-      return this.repository.find({ status });
+  public async getAllOrdersForAllUsers(...statuses: OrderStatus[]): Promise<OrderModel[]> {
+    if (statuses.length > 0) {
+      return this.repository.find({
+        where: {
+          status: In(statuses),
+        },
+      });
     }
     return this.repository.find();
   }

--- a/services/EmailService.ts
+++ b/services/EmailService.ts
@@ -20,6 +20,8 @@ export default class EmailService {
   private static readonly orderConfirmationTemplate = EmailService.readTemplate('orderConfirmation.ejs');
 
   private static readonly orderCancellationTemplate = EmailService.readTemplate('orderCancellation.ejs');
+  
+  private static readonly automatedOrderCancellationTemplate = EmailService.readTemplate('cancelPendingOrdersConfirmation.ejs');
 
   private static readonly orderPickupMissedTemplate = EmailService.readTemplate('orderPickupMissed.ejs');
 
@@ -104,6 +106,24 @@ export default class EmailService {
       await this.sendEmail(data);
     } catch (error) {
       log.warn(`Failed to send order cancellation email to ${email}`, { error });
+    }
+  }
+
+  public async sendAutomatedOrderCancellation(email: string, firstName: string, order: OrderInfo) {
+    try {
+      const data = {
+        to: email,
+        from: Config.email.user,
+        subject: 'ACM UCSD Merch Store - Automated Order Cancellation',
+        html: ejs.render(EmailService.automatedOrderCancellationTemplate, {
+          firstName,
+          order,
+          orderItems: ejs.render(EmailService.itemDisplayTemplate, { items: order.items, totalCost: order.totalCost }),
+        }),
+      };
+      await this.sendEmail(data);
+    } catch (error) {
+      log.warn(`Failed to send automated order cancellation email to ${email}`, { error });
     }
   }
 

--- a/services/EmailService.ts
+++ b/services/EmailService.ts
@@ -20,8 +20,9 @@ export default class EmailService {
   private static readonly orderConfirmationTemplate = EmailService.readTemplate('orderConfirmation.ejs');
 
   private static readonly orderCancellationTemplate = EmailService.readTemplate('orderCancellation.ejs');
-  
-  private static readonly automatedOrderCancellationTemplate = EmailService.readTemplate('cancelPendingOrdersConfirmation.ejs');
+
+  private static readonly automatedOrderCancellationTemplate = EmailService
+    .readTemplate('cancelPendingOrdersConfirmation.ejs');
 
   private static readonly orderPickupMissedTemplate = EmailService.readTemplate('orderPickupMissed.ejs');
 

--- a/services/MerchStoreService.ts
+++ b/services/MerchStoreService.ts
@@ -601,7 +601,8 @@ export default class MerchStoreService {
     await this.emailService.sendAutomatedOrderCancellation(user.email, user.firstName, orderUpdateInfo);
   }
 
-  private static async buildOrderCancellationInfo(order: OrderModel, refundedItems: OrderItemModel[], txn: EntityManager) {
+  private static async buildOrderCancellationInfo(order: OrderModel, refundedItems: OrderItemModel[],
+    txn: EntityManager): Promise<OrderInfo> {
     const orderRepository = Repositories.merchOrder(txn);
     const upsertedOrder = await orderRepository.upsertMerchOrder(order, { status: OrderStatus.CANCELLED });
     const orderWithOnlyUnfulfilledItems = OrderModel.merge(upsertedOrder, { items: refundedItems });

--- a/services/MerchStoreService.ts
+++ b/services/MerchStoreService.ts
@@ -583,7 +583,7 @@ export default class MerchStoreService {
     });
   }
 
-  private async refundAndConfirmOrderCancellation(order: OrderModel, user: UserModel, txn: EntityManager) {    
+  private async refundAndConfirmOrderCancellation(order: OrderModel, user: UserModel, txn: EntityManager) {
     // refund and restock items
     const refundedItems = await MerchStoreService.refundAndRestockItems(order, user, txn);
 
@@ -596,7 +596,8 @@ export default class MerchStoreService {
     await this.emailService.sendOrderCancellation(user.email, user.firstName, orderUpdateInfo);
   }
 
-  private static async refundAndRestockItems(order: OrderModel, user: UserModel, txn: EntityManager): Promise<OrderItemModel[]> {
+  private static async refundAndRestockItems(order: OrderModel, user: UserModel, txn: EntityManager):
+  Promise<OrderItemModel[]> {
     // refund only the items that haven't been fulfilled yet
     const unfulfilledItems = order.items.filter((item) => !item.fulfilled);
     const refundValue = unfulfilledItems.reduce((refund, item) => refund + item.salePriceAtPurchase, 0);
@@ -612,7 +613,7 @@ export default class MerchStoreService {
     return unfulfilledItems;
   }
 
-  private async refundAndConfirmAutomatedOrderCancellation(order: OrderModel, user: UserModel, txn: EntityManager) {    
+  private async refundAndConfirmAutomatedOrderCancellation(order: OrderModel, user: UserModel, txn: EntityManager) {
     // refund and restock items
     const refundedItems = await MerchStoreService.refundAndRestockItems(order, user, txn);
 
@@ -622,7 +623,7 @@ export default class MerchStoreService {
     const orderWithOnlyUnfulfilledItems = OrderModel.merge(upsertedOrder, { items: refundedItems });
     const orderUpdateInfo = await MerchStoreService
       .buildOrderUpdateInfo(orderWithOnlyUnfulfilledItems, upsertedOrder.pickupEvent, txn);
-    await this.emailService.sendOrderCancellation(user.email, user.firstName, orderUpdateInfo);
+    await this.emailService.sendAutomatedOrderCancellation(user.email, user.firstName, orderUpdateInfo);
   }
 
   /**
@@ -876,7 +877,9 @@ export default class MerchStoreService {
       const pendingOrders = await merchOrderRepository.getAllOrdersForAllUsers(
         ...MerchStoreService.pendingOrderStatuses(),
       );
-      await Promise.all(pendingOrders.map((order) => this.refundAndConfirmOrderCancellation(order, order.user, txn)));
+      await Promise.all(pendingOrders.map(
+        (order) => this.refundAndConfirmAutomatedOrderCancellation(order, order.user, txn),
+      ));
       const activityRepository = Repositories.activity(txn);
       await activityRepository.logActivity({
         user,

--- a/templates/cancelPendingOrdersConfirmation.ejs
+++ b/templates/cancelPendingOrdersConfirmation.ejs
@@ -1,0 +1,138 @@
+<!doctype html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Order Cancellation</title>
+    <style>
+        /* -------------------------------------
+            INLINED WITH htmlemail.io/inline
+        ------------------------------------- */
+        /* -------------------------------------
+            RESPONSIVE AND MOBILE FRIENDLY STYLES
+        ------------------------------------- */
+        @media only screen and (max-width: 620px) {
+            table[class=body] h1 {
+                font-size: 28px !important;
+                margin-bottom: 10px !important;
+            }
+            table[class=body] p,
+            table[class=body] ul,
+            table[class=body] ol,
+            table[class=body] td,
+            table[class=body] span,
+            table[class=body] a {
+                font-size: 16px !important;
+            }
+            table[class=body] .wrapper,
+            table[class=body] .article {
+                padding: 10px !important;
+            }
+            table[class=body] .content {
+                padding: 0 !important;
+            }
+            table[class=body] .container {
+                padding: 0 !important;
+                width: 100% !important;
+            }
+            table[class=body] .main {
+                border-left-width: 0 !important;
+                border-radius: 0 !important;
+                border-right-width: 0 !important;
+            }
+            table[class=body] .btn table {
+                width: 100% !important;
+            }
+            table[class=body] .btn a {
+                width: 100% !important;
+            }
+            table[class=body] .img-responsive {
+                height: auto !important;
+                max-width: 100% !important;
+                width: auto !important;
+            }
+        }
+
+        /* -------------------------------------
+            PRESERVE THESE STYLES IN THE HEAD
+        ------------------------------------- */
+        @media all {
+            .ExternalClass {
+                width: 100%;
+            }
+            .ExternalClass,
+            .ExternalClass p,
+            .ExternalClass span,
+            .ExternalClass font,
+            .ExternalClass td,
+            .ExternalClass div {
+                line-height: 100%;
+            }
+            .apple-link a {
+                color: inherit !important;
+                font-family: inherit !important;
+                font-size: inherit !important;
+                font-weight: inherit !important;
+                line-height: inherit !important;
+                text-decoration: none !important;
+            }
+            .btn-primary table td:hover {
+                background-color: #34495e !important;
+            }
+            .btn-primary a:hover {
+                background-color: #34495e !important;
+                border-color: #34495e !important;
+            }
+        }
+    </style>
+</head>
+<body class="" style="background-color: #f6f6f6; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+<table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background-color: #f6f6f6;">
+    <tr>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; Margin: 0 auto; max-width: 580px; padding: 10px; width: 580px;">
+            <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 580px; padding: 10px;">
+
+                <!-- START CENTERED WHITE CONTAINER -->
+                <table class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 3px;">
+
+                    <!-- START MAIN CONTENT AREA -->
+                    <tr>
+                        <td class="wrapper" style="font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 20px;">
+                            <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+                                <tr>
+                                    <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
+                                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Hi <%= firstName %>,</p>
+                                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">You had an order placed on ACM's Membership Portal that had not been fulfilled by the end of the past quarter. Your order has been cancelled, and the following items have been fully refunded to your account:</p>
+                                        <%- orderItems %>
+                                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Regards, <br />ACM UCSD</p>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+
+                    <!-- END MAIN CONTENT AREA -->
+                </table>
+
+                <!-- START FOOTER -->
+                <div class="footer" style="clear: both; Margin-top: 10px; text-align: center; width: 100%;">
+                    <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;">
+                        <tr>
+                            <td class="content-block" style="font-family: sans-serif; vertical-align: top; padding-bottom: 10px; padding-top: 10px; font-size: 12px; color: #999999; text-align: center;">
+                                <span class="apple-link" style="color: #999999; font-size: 12px; text-align: center;">Please do not reply to this email.</span>
+                                <br>You can contact us at <a href="mailto:acm@ucsd.edu" style="color: #999999; text-decoration: underline !important;">acm@ucsd.edu</a></a>.
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+                <!-- END FOOTER -->
+
+                <!-- END CENTERED WHITE CONTAINER -->
+            </div>
+        </td>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">&nbsp;</td>
+    </tr>
+</table>
+</body>
+</html>

--- a/templates/cancelPendingOrdersConfirmation.ejs
+++ b/templates/cancelPendingOrdersConfirmation.ejs
@@ -3,7 +3,7 @@
 <head>
     <meta name="viewport" content="width=device-width">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Order Cancellation</title>
+    <title>Automated Order Cancellation</title>
     <style>
         /* -------------------------------------
             INLINED WITH htmlemail.io/inline
@@ -103,7 +103,7 @@
                                 <tr>
                                     <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;">
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Hi <%= firstName %>,</p>
-                                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">You had an order placed on ACM's Membership Portal that had not been fulfilled by the end of the past quarter. Your order has been cancelled, and the following items have been fully refunded to your account:</p>
+                                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">You placed an order on ACM's Membership Portal that had not been fulfilled by the end of the most recent quarter. Your order has been cancelled, and the following items have been fully refunded to your account:</p>
                                         <%- orderItems %>
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; Margin-bottom: 15px;">Regards, <br />ACM UCSD</p>
                                     </td>

--- a/tests/merchOrder.test.ts
+++ b/tests/merchOrder.test.ts
@@ -632,8 +632,12 @@ describe('merch orders', () => {
     await conn.manager.update(OrderModel, { user: pickupCancelledMember }, { status: OrderStatus.PICKUP_CANCELLED });
     await conn.manager.update(OrderModel, { user: pickupMissedMember }, { status: OrderStatus.PICKUP_MISSED });
 
-    // cancell all pending orders
-    const merchController = ControllerFactory.merchStore(conn);
+    const emailService = mock(EmailService);
+    when(emailService.sendAutomatedOrderCancellation(anything(), anything(), anything()))
+      .thenResolve();
+
+    // cancel all pending orders
+    const merchController = ControllerFactory.merchStore(conn, emailService);
     await merchController.cancelAllPendingMerchOrders(storeManager);
     // (making sure that store distributors cannot)
     expect(merchController.cancelAllPendingMerchOrders(merchDistributor))


### PR DESCRIPTION
Adds a new template to let members know that their order was cancelled second-hand because they didn't pick up their merchandise by the end of the quarter, since otherwise they might be confused why their order was suddenly cancelled.

Example email:
![image](https://user-images.githubusercontent.com/33337209/160521592-dabfaaa5-64db-4b8c-ad8b-276885a55a04.png)
