### PR TITLE
Add required 'isResumeVisible' field to upload resume route

### DIFF
--- a/api/controllers/ResumeController.ts
+++ b/api/controllers/ResumeController.ts
@@ -18,7 +18,7 @@ import ResumeService from '../../services/ResumeService';
 import { UserModel } from '../../models/UserModel';
 import { AuthenticatedUser } from '../decorators/AuthenticatedUser';
 import { File, MediaType, GetVisibleResumesResponse, PatchResumeResponse, UpdateResumeResponse } from '../../types';
-import { PatchResumeRequest } from '../validators/ResumeControllerRequests';
+import { PatchResumeRequest, UploadResumeRequest } from '../validators/ResumeControllerRequests';
 import { UuidParam } from '../validators/GenericRequests';
 
 @UseBefore(UserAuthentication)
@@ -36,6 +36,7 @@ export class ResumeController {
   @Post()
   async uploadResume(@UploadedFile('file',
     { options: StorageService.getFileOptions(MediaType.RESUME) }) file: File,
+    @Body() uploadResumeRequest: UploadResumeRequest,
     @AuthenticatedUser() user: UserModel): Promise<UpdateResumeResponse> {
     if (path.extname(file.originalname) !== '.pdf') throw new BadRequestError('Filetype must be \'.pdf\'');
 
@@ -44,7 +45,7 @@ export class ResumeController {
 
     const fileName = file.originalname.substring(0, file.originalname.lastIndexOf('.'));
     const url = await this.storageService.uploadToFolder(file, MediaType.RESUME, fileName, user.uuid);
-    const resume = await this.resumeService.updateResume(user, url);
+    const resume = await this.resumeService.updateResume(user, url, uploadResumeRequest.isResumeVisible);
 
     return { error: null, resume: resume.getPublicResume() };
   }

--- a/api/validators/ResumeControllerRequests.ts
+++ b/api/validators/ResumeControllerRequests.ts
@@ -9,6 +9,7 @@ import {
 export class UploadResumeRequest implements IUploadResumeRequest {
   // IsBooleanString is used here instead of IsBoolean since multipart/form-data
   // field types are all string or files (no boolean types)
+  @IsDefined()
   @IsBooleanString()
   isResumeVisible: boolean;
 }

--- a/api/validators/ResumeControllerRequests.ts
+++ b/api/validators/ResumeControllerRequests.ts
@@ -1,9 +1,17 @@
 import { Type } from 'class-transformer';
-import { IsBoolean, IsDefined, ValidateNested } from 'class-validator';
+import { IsBoolean, IsBooleanString, IsDefined, ValidateNested } from 'class-validator';
 import {
+  UploadResumeRequest as IUploadResumeRequest,
   ResumePatches as IResumePatches,
   PatchResumeRequest as IPatchResumeRequest,
 } from '../../types';
+
+export class UploadResumeRequest implements IUploadResumeRequest {
+  // IsBooleanString is used here instead of IsBoolean since multipart/form-data
+  // field types are all string or files (no boolean types)
+  @IsBooleanString()
+  isResumeVisible: boolean;
+}
 
 export class ResumePatches implements IResumePatches {
   @IsBoolean()

--- a/services/ResumeService.ts
+++ b/services/ResumeService.ts
@@ -22,7 +22,7 @@ export default class ResumeService {
     return resumes;
   }
 
-  public async updateResume(user: UserModel, resumeURL: string): Promise<ResumeModel> {
+  public async updateResume(user: UserModel, resumeURL: string, isResumeVisible: boolean): Promise<ResumeModel> {
     return this.transactions.readWrite(async (txn) => {
       const resumeRepository = Repositories.resume(txn);
       const oldResume = await resumeRepository.findByUserUuid(user.uuid);
@@ -30,6 +30,7 @@ export default class ResumeService {
 
       const resume = await resumeRepository.upsertResume(ResumeModel.create({
         user,
+        isResumeVisible,
         url: resumeURL,
       }));
 

--- a/tests/resume.test.ts
+++ b/tests/resume.test.ts
@@ -74,7 +74,7 @@ describe('resume fetching', () => {
 });
 
 describe('upload resume', () => {
-  test('authenticated user can upload resume', async () => {
+  test('an authenticated user can upload a resume with visibility details', async () => {
     const conn = await DatabaseConnection.get();
     const member = UserFactory.fake();
     await new PortalState()
@@ -89,9 +89,12 @@ describe('upload resume', () => {
       conn,
       instance(storageService),
     );
-    const response = await resumeController.uploadResume(resume, member);
+    const request = { isResumeVisible: true };
+    const response = await resumeController.uploadResume(resume, request, member);
+
     expect(response.error).toBe(null);
     expect(response.resume.url).toBe(fileLocation);
+    expect(response.resume.isResumeVisible).toBe(true);
 
     verify(storageService.deleteAtUrl(fileLocation)).never();
     verify(
@@ -122,11 +125,12 @@ describe('upload resume', () => {
       conn,
       instance(storageService),
     );
-    const response = await resumeController.uploadResume(resume, member);
+    const request = { isResumeVisible: true };
+    const response = await resumeController.uploadResume(resume, request, member);
     expect(response.error).toBe(null);
 
     const newResume = FileFactory.pdf(Config.file.MAX_RESUME_FILE_SIZE / 2);
-    const response1 = await resumeController.uploadResume(newResume, member);
+    const response1 = await resumeController.uploadResume(newResume, request, member);
     expect(response1.error).toBe(null);
 
     const repository = conn.getRepository(ResumeModel);
@@ -164,13 +168,14 @@ describe('upload resume', () => {
     const image = FileFactory.image(Config.file.MAX_RESUME_FILE_SIZE / 2);
     const fileLocation = 'fake location';
 
-    const userController = ControllerFactory.resume(
+    const resumeController = ControllerFactory.resume(
       conn,
       Mocks.storage(fileLocation),
     );
-    expect(async () => {
-      await userController.uploadResume(image, member);
-    }).rejects.toThrow(BadRequestError);
+    const request = { isResumeVisible: true };
+
+    await expect(resumeController.uploadResume(image, request, member))
+      .rejects.toThrow(BadRequestError);
   });
 });
 

--- a/types/ApiRequests.ts
+++ b/types/ApiRequests.ts
@@ -281,6 +281,12 @@ export interface GetCartRequest {
 }
 
 // RESUMES
+/* Request object does not have nested property because the API request is of
+type multipart/form-data which does not support nested properties */
+export interface UploadResumeRequest {
+  isResumeVisible?: boolean
+}
+
 export interface ResumePatches {
   isResumeVisible?: boolean;
 }


### PR DESCRIPTION
Adds a field to set resume visibility on resume upload. This is a requirement for the route per the design of resume uploads, but until now it has not existed in the API spec:

![image](https://user-images.githubusercontent.com/33337209/214709900-51d0a522-9dcc-49f4-91fc-ba47f0890529.png)


