### PR TITLE
Start draft for delete route

### DIFF
--- a/api/controllers/UserController.ts
+++ b/api/controllers/UserController.ts
@@ -1,5 +1,5 @@
 import {
-  JsonController, Params, Get, Post, Patch, UseBefore, UploadedFile, Body,
+  JsonController, Params, Get, Post, Patch, UseBefore, UploadedFile, Body, Delete,
 } from 'routing-controllers';
 import { UserModel } from '../../models/UserModel';
 import UserAccountService from '../../services/UserAccountService';
@@ -14,6 +14,7 @@ import {
   GetUserResponse,
   GetCurrentUserResponse,
   PatchUserResponse,
+  DeleteUserResponse,
 } from '../../types';
 import { UuidParam } from '../validators/GenericRequests';
 import { PatchUserRequest } from '../validators/UserControllerRequests';
@@ -76,5 +77,11 @@ export class UserController {
     @AuthenticatedUser() user: UserModel): Promise<PatchUserResponse> {
     const patchedUser = await this.userAccountService.update(user, patchUserRequest.user);
     return { error: null, user: patchedUser.getFullUserProfile() };
+  }
+
+  @Delete()
+  async deleteAccount(@AuthenticatedUser() user: UserModel): Promise<DeleteUserResponse> {
+    await this.userAccountService.delete(user);
+    return { error: null };
   }
 }

--- a/repositories/UserRepository.ts
+++ b/repositories/UserRepository.ts
@@ -1,8 +1,9 @@
 import { EntityRepository, In } from 'typeorm';
 import * as bcrypt from 'bcrypt';
+import FactoryUtils from 'tests/data/FactoryUtils';
 import { Activity } from '../types/internal';
 import { UserModel } from '../models/UserModel';
-import { Uuid } from '../types';
+import { UserAccessType, UserState, Uuid } from '../types';
 import { BaseRepository } from './BaseRepository';
 
 @EntityRepository(UserModel)
@@ -81,5 +82,24 @@ export class UserRepository extends BaseRepository<UserModel> {
         credits: () => `credits + ${points * 100}`,
       })
       .execute();
+  }
+
+  public async deleteUser(user: UserModel) {
+    const clearedSensitiveFields: Partial<UserModel> = {
+      email: `deleted-user-${FactoryUtils.randomHexString()}@ucsd.edu`,
+      profilePicture: null,
+      firstName: 'Deleted',
+      lastName: 'User',
+      graduationYear: 0,
+      major: 'Deleted',
+      points: 0,
+      credits: 0,
+      lastLogin: new Date(0),
+      bio: null,
+      accessType: UserAccessType.RESTRICTED,
+      state: UserState.BLOCKED,
+    };
+    const deletedUser = { ...user, ...clearedSensitiveFields };
+    return this.repository.save(deletedUser);
   }
 }

--- a/services/UserAccountService.ts
+++ b/services/UserAccountService.ts
@@ -97,6 +97,10 @@ export default class UserAccountService {
     });
   }
 
+  public async delete(user: UserModel): Promise<UserModel> {
+    return this.transactions.readWrite(async (txn) => Repositories.user(txn).deleteUser(user));
+  }
+
   public async updateProfilePicture(user: UserModel, profilePicture: string): Promise<UserModel> {
     return this.transactions.readWrite(async (txn) => Repositories
       .user(txn)

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -1,0 +1,33 @@
+import { ControllerFactory } from './controllers';
+import { DatabaseConnection, PortalState, UserFactory } from './data';
+
+beforeAll(async () => {
+  await DatabaseConnection.connect();
+});
+
+beforeEach(async () => {
+  await DatabaseConnection.clear();
+});
+
+afterAll(async () => {
+  await DatabaseConnection.clear();
+  await DatabaseConnection.close();
+});
+
+describe('Delete user account', () => {
+  test('Deleted user account cannot log in', async () => {
+    const conn = await DatabaseConnection.get();
+    const account = UserFactory.fake();
+
+    await new PortalState().createUsers(account).write();
+    const userController = await ControllerFactory.user(conn);
+
+    const deletedUserResponse = await userController.deleteAccount(account);
+
+    expect(deletedUserResponse).toStrictEqual({ error: null });
+  });
+  test('Deleted user account is not viewable to other members', async () => {
+  });
+  test('Deleted user account is still counted for event attendance', async () => {
+  });
+});

--- a/types/ApiResponses.ts
+++ b/types/ApiResponses.ts
@@ -346,6 +346,8 @@ export interface PatchUserResponse extends ApiResponse {
   user: PrivateProfile;
 }
 
+export interface DeleteUserResponse extends ApiResponse {}
+
 export interface GetFeedbackResponse extends ApiResponse {
   feedback: PublicFeedback[];
 }


### PR DESCRIPTION
Leaving as a draft PR for now - basic functionality seems to work to remove all sensitive data and update account state. Still want to discuss tests and edge cases later.

One peculiar thing is that a deleted account can continue to use their bearer token to make authenticated requests, however this would be a FE issue to clear the bearer token since re-logging in would no longer work.