### PR TITLE
Update CI to build code into ARM and to tag Docker images 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,6 @@ jobs:
 
           # See https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
           # for details
-
-          # TODO: tag both the git hash AND latest in the build command once prod ready
           command: |
             GIT_HASH=$(echo $CIRCLE_SHA1 | cut -c -7)
             echo "$DOCKER_PASS" | docker login --username $DOCKER_USER --password-stdin
@@ -96,6 +94,7 @@ jobs:
               --cache-from type=local,src=/caches/docker-buildx \
               --cache-to type=local,dest=/caches/docker-buildx,mode=max \
               --tag acmucsd/membership-portal-api:latest \
+              --tag acmucsd/membership-portal-api:$GIT_HASH \
               --push .
       - save_cache:
           key: v1-{{ .Branch }}-{{ epoch }}
@@ -112,20 +111,30 @@ jobs:
       - run:
           command: |
             GIT_HASH=$(echo $CIRCLE_SHA1 | cut -c -7)
-            docker run caprover/cli-caprover:v2.1.1 caprover deploy --caproverUrl https://captain.testing.caprover.acmucsd.com --caproverPassword $CAPROVER_PASS --caproverApp membership-portal-api-testing --imageName acmucsd/membership-portal-api:latest
-            docker run caprover/cli-caprover:v2.1.1 caprover deploy --caproverUrl https://captain.testing.caprover.acmucsd.com --caproverPassword $CAPROVER_PASS --caproverApp membership-portal-api --imageName acmucsd/membership-portal-api:latest
+            docker run caprover/cli-caprover:v2.1.1 caprover deploy --caproverUrl https://captain.caprover.acmucsd.com --caproverPassword $CAPROVER_PASS --caproverApp membership-portal-api-testing --imageName acmucsd/membership-portal-api:$GIT_HASH
+            docker run caprover/cli-caprover:v2.1.1 caprover deploy --caproverUrl https://captain.caprover.acmucsd.com --caproverPassword $CAPROVER_PASS --caproverApp membership-portal-api --imageName acmucsd/membership-portal-api:$GIT_HASH
 
 workflows:
   version: 2
   test_and_deploy:
     jobs:
+      - build
+      - lint
+      - test
       - image:
+          requires:
+            - build
+            - lint
+            - test
           filters:
             branches:
-              only: shravan/caprover-testing-deployment
+              only: master
       - deploy:
           requires:
+            - build
+            - lint
+            - test
             - image
           filters:
             branches:
-              only: shravan/caprover-testing-deployment
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,12 @@ jobs:
   image:
     working_directory: /app
     docker:
+      # This image is used for docker buildx compatibilities, which allows us to
+      # build to both x86 and ARM architectures. This allows us to use
+      # t4g (AWS Graviton instances backed by ARM architecture) and t3a instances
+      # (our old instance type) on AWS EC2. More details on the actual usage
+      # are below in the command section
+
       # Image and code adapted from https://www.docker.com/blog/multi-arch-build-what-about-circleci/
       - image: jdrouet/docker-with-buildx:stable
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,6 @@ jobs:
             docker run caprover/cli-caprover:v2.1.1 caprover deploy --caproverUrl https://captain.caprover.acmucsd.com --caproverPassword $CAPROVER_PASS --caproverApp membership-portal-api --imageName acmucsd/membership-portal-api:$GIT_HASH
 
 workflows:
-  version: 2
   test_and_deploy:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 jobs:
   build:
@@ -55,71 +55,77 @@ jobs:
   image:
     working_directory: /app
     docker:
-      - image: docker:20.10.2
+      # Image and code adapted from https://www.docker.com/blog/multi-arch-build-what-about-circleci/
+      - image: jdrouet/docker-with-buildx:stable
     steps:
       - checkout
       - setup_remote_docker:
           version: 20.10.2
+      # Caching done for docker images and stored for future workflows.
+      ## https://circleci.com/docs/caching
       - restore_cache:
           keys:
             - v1-{{ .Branch }}
           paths:
-            - /caches/app.tar
+            - /caches/docker-buildx
       - run:
-          name: Load Docker image layer cache
+          name: Push application Docker image
+          # The below command builds, tags, and pushes the docker image in a single step.
+          # There isn't a way to separate these steps - that is how buildx was designed.
+          # Caching is done for both loading the image and storing the image,
+          # and the platforms specified are both amd64 (i.e. x86) and arm64,
+          # meaning that both AWS Graviton instances and regular AMD
+          # instances can both use this image. Because both architectures need to be built,
+          # the build process will take longer than it historically has.
+
+          # the 'docker buildx create' command below creates a new builder instance that is capable
+          # of building multi-platform images, since the default instance does not
+          # have that capability by default.
+
+          # See https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
+          # for details
+
+          # TODO: tag both the git hash AND latest in the build command once prod ready
           command: |
-            set +o pipefail
-            docker load -i /caches/app.tar | true
-      - run:
-          name: Build application Docker image
-          command: |
-            docker build --cache-from=app -t app .
-      - run:
-          name: Save Docker image layer cache
-          command: |
-            mkdir -p /caches
-            docker save -o /caches/app.tar app
+            GIT_HASH=$(echo $CIRCLE_SHA1 | cut -c -7)
+            echo "$DOCKER_PASS" | docker login --username $DOCKER_USER --password-stdin
+            docker buildx create --name multi_platform_builder --use
+
+            docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              --cache-from type=local,src=/caches/docker-buildx \
+              --cache-to type=local,dest=/caches/docker-buildx,mode=max \
+              --tag acmucsd/membership-portal-api:latest \
+              --push .
       - save_cache:
           key: v1-{{ .Branch }}-{{ epoch }}
           paths:
-            - /caches/app.tar
-      - run:
-          name: Push application Docker image
-          command: |
-            echo "$DOCKER_PASS" | docker login --username $DOCKER_USER --password-stdin
-            docker tag app "acmucsd/membership-portal-api:latest"
-            docker push "acmucsd/membership-portal-api:latest"
+            - /caches/docker-buildx
+
   deploy:
+    environment:
+      GIT_HASH: $(echo $CIRCLE_SHA1 | cut -c -7)
     machine:
       enabled: true
     steps:
       - checkout
       - run:
           command: |
-            docker run caprover/cli-caprover:v2.1.1 caprover deploy --caproverUrl https://captain.app.acmucsd.com --caproverPassword $CAPROVER_PASS --caproverApp membership-portal-api --imageName acmucsd/membership-portal-api:latest
-            docker run caprover/cli-caprover:v2.1.1 caprover deploy --caproverUrl https://captain.app.acmucsd.com --caproverPassword $CAPROVER_PASS --caproverApp membership-portal-api-testing --imageName acmucsd/membership-portal-api:latest
+            GIT_HASH=$(echo $CIRCLE_SHA1 | cut -c -7)
+            docker run caprover/cli-caprover:v2.1.1 caprover deploy --caproverUrl https://captain.testing.caprover.acmucsd.com --caproverPassword $CAPROVER_PASS --caproverApp membership-portal-api-testing --imageName acmucsd/membership-portal-api:latest
+            docker run caprover/cli-caprover:v2.1.1 caprover deploy --caproverUrl https://captain.testing.caprover.acmucsd.com --caproverPassword $CAPROVER_PASS --caproverApp membership-portal-api --imageName acmucsd/membership-portal-api:latest
 
 workflows:
   version: 2
   test_and_deploy:
     jobs:
-      - build
-      - lint
-      - test
       - image:
-          requires:
-            - build
-            - lint
-            - test
           filters:
             branches:
-              only: master
+              only: shravan/caprover-testing-deployment
       - deploy:
           requires:
-            - build
-            - lint
-            - test
             - image
           filters:
             branches:
-              only: master
+              only: shravan/caprover-testing-deployment


### PR DESCRIPTION
Closes #332.

This PR introduces a bunch of changes to our CI to support the migration of the portal instance on AWS to a cheaper instance backed by AWS Graviton processors. Graviton processors are ARM-based processors built by AWS themselves that boast similar levels of performance to traditional x86 processors, but at a cheaper cost due to the fact that they are built in-house. This change is part of an overall effort by us to decrease our AWS costs - the full details and numbers can be found [on our Notion](https://www.notion.so/acmucsd/AWS-Cost-Reduction-d5cf7cadd1254726906942ee004e0ea6).

There are many changes (some subtle) to the CI and overall infrastructure, but here is a breakdown of the notable ones:
* Portal instance now lives on a t4g.small instance vs. a t3a.small instance, and is now running on ARM
* CI now compiles our Docker image into both x86 and ARM for backwards compatibility (and in case we need to switch off back to x86 for any reason). This is done with the help of [Docker's buildx utility](https://docs.docker.com/engine/reference/commandline/buildx/). There are comments in the CI code itself that hopefully explain what's happening to build the Docker image into multiple architectures.
* CI now deploys image onto a new Caprover instance which lives on the new t4g.small instance (which is pointed to by caprover.acmucsd.com, rather than the old app.acmucsd.com).
* Docker images are now tagged with the first 7 characters of the Git commit hash on master - this resolves the issue linked above and allows us to rollback images as needed (more details are in the issue itself).

On merge, this PR will tag the Docker image built with the new Git commit hash structure, so both the prod and testing servers will be running based off of these hash-tagged images, and not the `latest` tag.