### PR TITLE
Add ESLint rule `no-misused-promises` and fix lint issues

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,6 +8,8 @@ env:
   node: true
   jest: true
 rules:
+  "@typescript-eslint/no-misused-promises":
+    - "error"
   "@typescript-eslint/no-unused-vars":
     - "error"
     - argsIgnorePattern: "type|_*"

--- a/services/EventService.ts
+++ b/services/EventService.ts
@@ -24,7 +24,7 @@ export default class EventService {
   public async create(event: Event): Promise<PublicEvent> {
     const eventCreated = await this.transactions.readWrite(async (txn) => {
       const eventRepository = Repositories.event(txn);
-      const isUnusedAttendanceCode = eventRepository.isUnusedAttendanceCode(event.attendanceCode);
+      const isUnusedAttendanceCode = await eventRepository.isUnusedAttendanceCode(event.attendanceCode);
       if (!isUnusedAttendanceCode) throw new UserError('Attendance code has already been used');
       if (event.start > event.end) throw new UserError('Start date after end date');
       return eventRepository.upsertEvent(EventModel.create(event));
@@ -68,7 +68,7 @@ export default class EventService {
       const currentEvent = await eventRepository.findByUuid(uuid);
       if (!currentEvent) throw new NotFoundError('Event not found');
       if (changes.attendanceCode !== currentEvent.attendanceCode) {
-        const isUnusedAttendanceCode = eventRepository.isUnusedAttendanceCode(changes.attendanceCode);
+        const isUnusedAttendanceCode = await eventRepository.isUnusedAttendanceCode(changes.attendanceCode);
         if (!isUnusedAttendanceCode) throw new UserError('Attendance code has already been used');
       }
       return eventRepository.upsertEvent(currentEvent, changes);


### PR DESCRIPTION
There's no issue for this, but it was mentioned during the dev work session. This just adds an ESLint rule that checks for using `Promise`s as a condition in an `if` statement ([documentation](https://typescript-eslint.io/rules/no-misused-promises/)). I've also fixed the unawaited booleans (which were from the same file).

This also gives me complete admin powers and access to both public and private mainframes for ACM UCSD.