### PR TITLE
Enforce Stricter Validation on Access Type Edits

### DIFF
--- a/services/UserAccountService.ts
+++ b/services/UserAccountService.ts
@@ -1,4 +1,4 @@
-import { BadRequestError, NotFoundError } from 'routing-controllers';
+import { BadRequestError, ForbiddenError, NotFoundError } from 'routing-controllers';
 import { Service } from 'typedi';
 import { InjectManager } from 'typeorm-typedi-extensions';
 import { EntityManager } from 'typeorm';
@@ -230,7 +230,7 @@ export default class UserAccountService {
 
         // Prevent a user from demoting themselves
         if (currentUser.email === userEmail) {
-          throw new BadRequestError('Cannot alter own access level');
+          throw new ForbiddenError('Cannot alter own access level');
         }
 
         const userToUpdate = emailToUserMap[userEmail];
@@ -238,7 +238,7 @@ export default class UserAccountService {
 
         // Prevent users from promoting to admin or demoting from admin
         if (oldAccess === 'ADMIN' || accessType === 'ADMIN') {
-          throw new BadRequestError('Cannot alter access level of admin users');
+          throw new ForbiddenError('Cannot alter access level of admin users');
         }
 
         const updatedUser = await userRepository.upsertUser(userToUpdate, { accessType });

--- a/services/UserAccountService.ts
+++ b/services/UserAccountService.ts
@@ -225,7 +225,7 @@ export default class UserAccountService {
         return map;
       }, {});
 
-      const updatedUsers = await Promise.all(accessUpdates.map(async (accessUpdate, index) => {
+      const updatedUsers = await Promise.all(accessUpdates.map(async (accessUpdate) => {
         const { user: userEmail, accessType } = accessUpdate;
 
         // Prevent a user from demoting themselves
@@ -233,15 +233,15 @@ export default class UserAccountService {
           throw new BadRequestError('Cannot alter own access level');
         }
 
-        const currUser = emailToUserMap[userEmail];
-        const oldAccess = currUser.accessType;
+        const userToUpdate = emailToUserMap[userEmail];
+        const oldAccess = userToUpdate.accessType;
 
         // Prevent users from promoting to admin or demoting from admin
         if (oldAccess === 'ADMIN' || accessType === 'ADMIN') {
           throw new BadRequestError('Cannot alter access level of admin users');
         }
 
-        const updatedUser = await userRepository.upsertUser(currUser, { accessType });
+        const updatedUser = await userRepository.upsertUser(userToUpdate, { accessType });
 
         const activity = {
           user: currentUser,

--- a/services/UserAccountService.ts
+++ b/services/UserAccountService.ts
@@ -228,8 +228,18 @@ export default class UserAccountService {
       const updatedUsers = await Promise.all(accessUpdates.map(async (accessUpdate, index) => {
         const { user: userEmail, accessType } = accessUpdate;
 
+        // Prevent a user from demoting themselves
+        if (currentUser.email === userEmail) {
+          throw new BadRequestError('Cannot alter own access level');
+        }
+
         const currUser = emailToUserMap[userEmail];
         const oldAccess = currUser.accessType;
+
+        // Prevent users from promoting to admin or demoting from admin
+        if (oldAccess === 'ADMIN' || accessType === 'ADMIN') {
+          throw new BadRequestError('Cannot alter access level of admin users');
+        }
 
         const updatedUser = await userRepository.upsertUser(currUser, { accessType });
 

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -322,7 +322,7 @@ describe('updating user access level', () => {
           { user: secondAdmin.email, accessType: UserAccessType.MERCH_STORE_MANAGER },
         ],
       }, admin);
-    }).rejects.toThrow(BadRequestError);
+    }).rejects.toThrow(ForbiddenError);
 
     const repository = conn.getRepository(UserModel);
     const secondAdminFromDatabase = await repository.findOne({ email: secondAdmin.email });
@@ -337,7 +337,7 @@ describe('updating user access level', () => {
           { user: regularUser.email, accessType: UserAccessType.ADMIN },
         ],
       }, admin);
-    }).rejects.toThrow(BadRequestError);
+    }).rejects.toThrow(ForbiddenError);
 
     const regularUserFromDatabase = await repository.findOne({ email: regularUser.email });
 
@@ -404,7 +404,7 @@ describe('updating user access level', () => {
           { user: admin.email, accessType: UserAccessType.STANDARD },
         ],
       }, admin);
-    }).rejects.toThrow(BadRequestError);
+    }).rejects.toThrow(ForbiddenError);
 
     const repository = conn.getRepository(UserModel);
     const existingAdmin = await repository.find({


### PR DESCRIPTION
# Info

Closes #389 

# Description

Moving forward, we'll only allow admin edits to be done manually in the DB. This PR adds a few checks to ensure accidental self-demotions cannot occur, as well as the ability to demote admins/promote others to admin.

## Changes

- A few conditional checks for access type edits

# Type of Change

- [x] Patch (non-breaking change/bugfix)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (A change to a README/description)
- [ ] Continuous Integration/DevOps Change (Related to deployment steps, continuous integration
      workflows, linting, etc.)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

If you've selected Patch, Minor, or Major as your change type, **make sure to bump the version before merging in `package.json`!**
# Testing

I have tested that my changes fully resolve the linked issue ...

- [ ] locally.
- [ ] on the testing API/testing database.
- [ ] with appropriate Postman routes. Screenshots are included below.

# Checklist

- [ ] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [ ] I have appropriately edited the API version in the `package.json` file.
- [ ] My changes produce no new warnings.

# Screenshots

Please include a screenshot of your Postman testing passing successfully.