### PR TITLE
Fix null linkedEvent for some Order routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acmucsd/membership-portal",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "REST API for ACM UCSD's membership portal.",
   "main": "index.d.ts",
   "files": [

--- a/repositories/MerchOrderRepository.ts
+++ b/repositories/MerchOrderRepository.ts
@@ -31,7 +31,7 @@ export class MerchOrderRepository extends BaseRepository<OrderModel> {
   }
 
   /**
-   * Gets all orders for all users. Returns the order joined with its pickup event.
+   * Gets all orders for all users. Returns the order joined with its pickup event and linked event.
    * Can optionally filter by order status.
    */
   public async getAllOrdersForAllUsers(...statuses: OrderStatus[]): Promise<OrderModel[]> {
@@ -42,29 +42,29 @@ export class MerchOrderRepository extends BaseRepository<OrderModel> {
         },
       });
     }
-    return this.repository.find();
-  }
-
-  /**
-   * Gets all orders for a given user. Returns the order joined with its pickup event and user.
-   */
-  public async getAllOrdersForUser(user: UserModel): Promise<OrderModel[]> {
-    //return this.repository.find({ user });
     return this.repository
       .createQueryBuilder('order')
       .leftJoinAndSelect('order.pickupEvent', 'orderPickupEvent')
-      .leftJoinAndSelect('order.items', 'orderItem')
       .leftJoinAndSelect('order.user', 'user')
-      .leftJoinAndSelect('orderItem.option', 'option')
-      .leftJoinAndSelect('option.item', 'merchItem')
-      .leftJoinAndSelect('merchItem.merchPhotos', 'merchPhotos')
+      .leftJoinAndSelect('orderPickupEvent.linkedEvent', 'linkedEvent')
+      .getMany();
+  }
+
+  /**
+   * Gets all orders for a given user. Returns the order joined with its pickup event, linked event, and user.
+   */
+  public async getAllOrdersForUser(user: UserModel): Promise<OrderModel[]> {
+    return this.repository
+      .createQueryBuilder('order')
+      .leftJoinAndSelect('order.pickupEvent', 'orderPickupEvent')
+      .leftJoinAndSelect('order.user', 'user')
       .leftJoinAndSelect('orderPickupEvent.linkedEvent', 'linkedEvent')
       .where('order.user = :uuid', { uuid: user.uuid })
       .getMany();
   }
 
   /**
-   * Gets all orders for a given user. Returns the order joined with its pickup event, user,
+   * Gets all orders for a given user. Returns the order joined with its pickup event, linked event, user,
    * merch item options, merch items, and merch item photos.
    */
   public async getAllOrdersWithItemsForUser(user: UserModel): Promise<OrderModel[]> {
@@ -75,6 +75,7 @@ export class MerchOrderRepository extends BaseRepository<OrderModel> {
       .leftJoinAndSelect('order.user', 'user')
       .leftJoinAndSelect('orderItem.option', 'option')
       .leftJoinAndSelect('option.item', 'merchItem')
+      .leftJoinAndSelect('orderPickupEvent.linkedEvent', 'linkedEvent')
       .leftJoinAndSelect('merchItem.merchPhotos', 'merchPhotos')
       .where('order.user = :uuid', { uuid: user.uuid })
       .getMany();

--- a/repositories/MerchOrderRepository.ts
+++ b/repositories/MerchOrderRepository.ts
@@ -75,7 +75,6 @@ export class MerchOrderRepository extends BaseRepository<OrderModel> {
       .leftJoinAndSelect('order.user', 'user')
       .leftJoinAndSelect('orderItem.option', 'option')
       .leftJoinAndSelect('option.item', 'merchItem')
-      .leftJoinAndSelect('orderPickupEvent.linkedEvent', 'linkedEvent')
       .leftJoinAndSelect('merchItem.merchPhotos', 'merchPhotos')
       .where('order.user = :uuid', { uuid: user.uuid })
       .getMany();

--- a/repositories/MerchOrderRepository.ts
+++ b/repositories/MerchOrderRepository.ts
@@ -64,7 +64,7 @@ export class MerchOrderRepository extends BaseRepository<OrderModel> {
   }
 
   /**
-   * Gets all orders for a given user. Returns the order joined with its pickup event, linked event, user,
+   * Gets all orders for a given user. Returns the order joined with its pickup event, user,
    * merch item options, merch items, and merch item photos.
    */
   public async getAllOrdersWithItemsForUser(user: UserModel): Promise<OrderModel[]> {

--- a/tests/Seeds.ts
+++ b/tests/Seeds.ts
@@ -52,7 +52,7 @@ async function seed(): Promise<void> {
   });
 
   const MEMBER_FRESHMAN = UserFactory.fake({
-    email: 'nsdange@ucsd.edu',
+    email: 'sisteine@ucsd.edu',
     accessType: UserAccessType.STANDARD,
     firstName: 'Steven',
     lastName: 'Steiner',

--- a/tests/Seeds.ts
+++ b/tests/Seeds.ts
@@ -52,7 +52,7 @@ async function seed(): Promise<void> {
   });
 
   const MEMBER_FRESHMAN = UserFactory.fake({
-    email: 'sisteine@ucsd.edu',
+    email: 'nsdange@ucsd.edu',
     accessType: UserAccessType.STANDARD,
     firstName: 'Steven',
     lastName: 'Steiner',


### PR DESCRIPTION
## Changes

- Added a left join in the get single order and get many orders query

# Type of Change

- [ ] Patch (non-breaking change/bugfix)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (A change to a README/description)
- [ ] Continuous Integration/DevOps Change (Related to deployment steps, continuous integration
      workflows, linting, etc.)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

If you've selected Patch, Minor, or Major as your change type, **make sure to bump the version before merging in `package.json`!**
# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally.
- [ ] on the testing API/testing database.
- [x] with appropriate Postman routes. Screenshots are included below.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [ ] I have appropriately edited the API version in the `package.json` file.
- [x] My changes produce no new warnings.

# Screenshots

<img width="1464" alt="image" src="https://github.com/acmucsd/membership-portal/assets/16010723/576e3118-cb68-445a-8127-f60969fbe91e">
<img width="1451" alt="Screenshot 2024-03-21 at 10 44 26 PM" src="https://github.com/acmucsd/membership-portal/assets/16010723/58fc8bcb-7386-4782-b676-0861014a0c58">


Please include a screenshot of your Postman testing passing successfully.