### PR TITLE
Hotfix: Fix inconsistent feedback query

### DIFF
--- a/repositories/FeedbackRepository.ts
+++ b/repositories/FeedbackRepository.ts
@@ -15,8 +15,11 @@ export class FeedbackRepository extends BaseRepository<FeedbackModel> {
     return this.getBaseFindQuery({}).where({ uuid }).getOne();
   }
 
+  // temporary fix for getting feedback for a user for an event
   public async getStandardUserFeedback(user: UserModel, options: FeedbackSearchOptions): Promise<FeedbackModel[]> {
     let query = this.getBaseFindQuery(options);
+    query = query.andWhere('feedback.user = :user', { user: user.uuid });
+
     return query.getMany();
   }
 

--- a/repositories/FeedbackRepository.ts
+++ b/repositories/FeedbackRepository.ts
@@ -15,8 +15,20 @@ export class FeedbackRepository extends BaseRepository<FeedbackModel> {
     return this.getBaseFindQuery({}).where({ uuid }).getOne();
   }
 
-  public async getAllFeedbackForUser(user: UserModel): Promise<FeedbackModel[]> {
-    return this.getBaseFindQuery({}).where({ user }).getMany();
+  // temporary fix for getting feedback for a user for an event
+  public async getStandardUserFeedback(user: UserModel, options: FeedbackSearchOptions): Promise<FeedbackModel[]> {
+    let query = this.getBaseFindQuery(options);
+    query = query.andWhere('feedback.user = :user', { user: user.uuid });
+
+    if (options.event) {
+      query = query.andWhere('feedback.event = :event', { event: options.event });
+    }
+
+    return query.getMany();
+  }
+
+  public async getAllFeedbackForUser(user: UserModel, options: FeedbackSearchOptions): Promise<FeedbackModel[]> {
+    return this.getBaseFindQuery(options).where({ user }).getMany();
   }
 
   public async upsertFeedback(feedback: FeedbackModel,

--- a/repositories/FeedbackRepository.ts
+++ b/repositories/FeedbackRepository.ts
@@ -15,15 +15,8 @@ export class FeedbackRepository extends BaseRepository<FeedbackModel> {
     return this.getBaseFindQuery({}).where({ uuid }).getOne();
   }
 
-  // temporary fix for getting feedback for a user for an event
   public async getStandardUserFeedback(user: UserModel, options: FeedbackSearchOptions): Promise<FeedbackModel[]> {
     let query = this.getBaseFindQuery(options);
-    query = query.andWhere('feedback.user = :user', { user: user.uuid });
-
-    if (options.event) {
-      query = query.andWhere('feedback.event = :event', { event: options.event });
-    }
-
     return query.getMany();
   }
 

--- a/services/FeedbackService.ts
+++ b/services/FeedbackService.ts
@@ -25,7 +25,7 @@ export default class FeedbackService {
           .map((fb) => fb.getPublicFeedback());
       }
 
-      const userFeedback = await feedbackRepository.getAllFeedbackForUser(user);
+      const userFeedback = await feedbackRepository.getStandardUserFeedback(user, options);
       return userFeedback.map((fb) => fb.getPublicFeedback());
     });
   }

--- a/tests/feedback.test.ts
+++ b/tests/feedback.test.ts
@@ -164,7 +164,7 @@ describe('feedback submission', () => {
     const feedbackController = ControllerFactory.feedback(conn);
     await feedbackController.submitFeedback(buildFeedbackRequest(feedback1), member1);
     await feedbackController.submitFeedback(buildFeedbackRequest(feedback2), member2);
-    const user1Feedback = await feedbackController.getFeedback({}, member1);
+    const user1Feedback = await feedbackController.getFeedback({ user: member1.uuid }, member1);
 
     expect(user1Feedback.feedback).toHaveLength(1);
 


### PR DESCRIPTION
# Description

What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context.

The query we use for GET /feedback is inconsistent with the way frontend wants to use it, as well as the rest of our portal structure. This is a temporary fix that should get the job done, but I will be doing a larger refactor with new routes later this week.

## Changes

- Fixed query

# Type of Change

- [x] Patch (non-breaking change/bugfix)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (A change to a README/description)
- [ ] Continuous Integration/DevOps Change (Related to deployment steps, continuous integration
      workflows, linting, etc.)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

If you've selected Patch, Minor, or Major as your change type, **make sure to bump the version before merging in `package.json`!**
# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally.
- [ ] on the testing API/testing database.
- [ ] with appropriate Postman routes. Screenshots are included below.

# Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have followed the style guidelines of this project.
- [ ] I have appropriately edited the API version in the `package.json` file.
- [ ] My changes produce no new warnings.

# Screenshots

Please include a screenshot of your Postman testing passing successfully.