### PR TITLE
Add event cover in create route

### DIFF
--- a/api/controllers/EventController.ts
+++ b/api/controllers/EventController.ts
@@ -128,8 +128,9 @@ export class EventController {
     @Body() createEventRequest: CreateEventRequest,
     @AuthenticatedUser() user: UserModel): Promise<CreateEventResponse> {
     if (!PermissionsService.canEditEvents(user)) throw new ForbiddenError();
-    const uniqueFileName = uuid();
-    createEventRequest.event.cover = await this.storageService.upload(file, MediaType.EVENT_COVER, uniqueFileName);
+    const fileName = file.originalname.substring(0, file.originalname.lastIndexOf('.'));;
+    createEventRequest.event.cover = await this.storageService.upload(file, MediaType.EVENT_COVER, fileName);
+    console.log(createEventRequest);
     const event = await this.eventService.create(createEventRequest.event);
     return { error: null, event };
   }

--- a/api/controllers/EventController.ts
+++ b/api/controllers/EventController.ts
@@ -8,7 +8,6 @@ import { UserModel } from '../../models/UserModel';
 import PermissionsService from '../../services/PermissionsService';
 import StorageService from '../../services/StorageService';
 import AttendanceService from '../../services/AttendanceService';
-import { v4 as uuid } from 'uuid';
 import {
   MediaType,
   File,
@@ -28,8 +27,6 @@ import {
   CreateEventRequest,
   SubmitEventFeedbackRequest,
 } from '../validators/EventControllerRequests';
-import { EventModel } from 'models/EventModel';
-import { create, uniq } from 'underscore';
 
 @JsonController('/event')
 export class EventController {
@@ -128,9 +125,8 @@ export class EventController {
     @Body() createEventRequest: CreateEventRequest,
     @AuthenticatedUser() user: UserModel): Promise<CreateEventResponse> {
     if (!PermissionsService.canEditEvents(user)) throw new ForbiddenError();
-    const fileName = file.originalname.substring(0, file.originalname.lastIndexOf('.'));;
+    const fileName = file.originalname.substring(0, file.originalname.lastIndexOf('.'));
     createEventRequest.event.cover = await this.storageService.upload(file, MediaType.EVENT_COVER, fileName);
-    console.log(createEventRequest);
     const event = await this.eventService.create(createEventRequest.event);
     return { error: null, event };
   }

--- a/services/EventService.ts
+++ b/services/EventService.ts
@@ -6,13 +6,17 @@ import { EventModel } from '../models/EventModel';
 import { Uuid, PublicEvent, Event, EventSearchOptions } from '../types';
 import Repositories, { TransactionsManager } from '../repositories';
 import { UserError } from '../utils/Errors';
+import StorageService from './StorageService';
 
 @Service()
 export default class EventService {
   private transactions: TransactionsManager;
 
-  constructor(@InjectManager() entityManager: EntityManager) {
+  private storageService: StorageService;
+
+  constructor(@InjectManager() entityManager: EntityManager, storageService: StorageService) {
     this.transactions = new TransactionsManager(entityManager);
+    this.storageService = storageService;
   }
 
   /**
@@ -25,8 +29,14 @@ export default class EventService {
     const eventCreated = await this.transactions.readWrite(async (txn) => {
       const eventRepository = Repositories.event(txn);
       const isUnusedAttendanceCode = await eventRepository.isUnusedAttendanceCode(event.attendanceCode);
-      if (!isUnusedAttendanceCode) throw new UserError('Attendance code has already been used');
-      if (event.start > event.end) throw new UserError('Start date after end date');
+      if (!isUnusedAttendanceCode) {
+        this.storageService.deleteAtUrl(event.cover);
+        throw new UserError('Attendance code has already been used');
+      }
+      if (event.start > event.end) {
+        this.storageService.deleteAtUrl(event.cover);
+        throw new UserError('Start date after end date');
+      }
       return eventRepository.upsertEvent(EventModel.create(event));
     });
     return eventCreated.getPublicEvent();

--- a/services/EventService.ts
+++ b/services/EventService.ts
@@ -29,7 +29,6 @@ export default class EventService {
     const eventCreated = await this.transactions.readWrite(async (txn) => {
       const eventRepository = Repositories.event(txn);
       const isUnusedAttendanceCode = await eventRepository.isUnusedAttendanceCode(event.attendanceCode);
-      // console.log(event.cover);
       if (!isUnusedAttendanceCode) {
         this.storageService.deleteAtUrl(event.cover);
         throw new UserError('Attendance code has already been used');
@@ -38,7 +37,6 @@ export default class EventService {
         this.storageService.deleteAtUrl(event.cover);
         throw new UserError('Start date after end date');
       }
-      console.log("Here");
       return eventRepository.upsertEvent(EventModel.create(event));
     });
     return eventCreated.getPublicEvent();

--- a/services/EventService.ts
+++ b/services/EventService.ts
@@ -29,6 +29,7 @@ export default class EventService {
     const eventCreated = await this.transactions.readWrite(async (txn) => {
       const eventRepository = Repositories.event(txn);
       const isUnusedAttendanceCode = await eventRepository.isUnusedAttendanceCode(event.attendanceCode);
+      // console.log(event.cover);
       if (!isUnusedAttendanceCode) {
         this.storageService.deleteAtUrl(event.cover);
         throw new UserError('Attendance code has already been used');
@@ -37,6 +38,7 @@ export default class EventService {
         this.storageService.deleteAtUrl(event.cover);
         throw new UserError('Start date after end date');
       }
+      console.log("Here");
       return eventRepository.upsertEvent(EventModel.create(event));
     });
     return eventCreated.getPublicEvent();

--- a/tests/controllers/ControllerFactory.ts
+++ b/tests/controllers/ControllerFactory.ts
@@ -54,9 +54,8 @@ export class ControllerFactory {
     return new AuthController(userAccountService, userAuthService, emailService);
   }
 
-  public static event(conn: Connection): EventController {
-    const eventService = new EventService(conn.manager);
-    const storageService = new StorageService();
+  public static event(conn: Connection, storageService = new StorageService()): EventController {
+    const eventService = new EventService(conn.manager, storageService);
     const attendanceService = new AttendanceService(conn.manager);
     return new EventController(eventService, storageService, attendanceService);
   }

--- a/tests/event.test.ts
+++ b/tests/event.test.ts
@@ -8,7 +8,7 @@ import { EventModel } from '../models/EventModel';
 import Mocks from './mocks/MockFactory';
 import { FileFactory } from './data/FileFactory';
 import { Config } from '../config';
-import { anything, verify } from 'ts-mockito';
+import { anything, instance, verify } from 'ts-mockito';
 
 beforeAll(async () => {
   await DatabaseConnection.connect();
@@ -55,7 +55,7 @@ describe('event creation', () => {
     // creating the event
     const cover = FileFactory.image(Config.file.MAX_EVENT_COVER_FILE_SIZE / 2);
     const storageService = Mocks.storage(fileLocation);
-    const eventController = ControllerFactory.event(conn, storageService);
+    const eventController = ControllerFactory.event(conn, instance(storageService));
     const eventResponse = await eventController.createEvent(cover, createEventRequest, admin);
 
     // verifying response from event creation
@@ -110,7 +110,7 @@ describe('event creation', () => {
     // verifying correct error
     const cover = FileFactory.image(Config.file.MAX_EVENT_COVER_FILE_SIZE / 2);
     const storageService = Mocks.storage(fileLocation);
-    const eventController = ControllerFactory.event(conn, storageService);
+    const eventController = ControllerFactory.event(conn, instance(storageService));
     await expect(eventController.createEvent(cover, createEventRequest, user))
       .rejects.toThrow(ForbiddenError);
     verify(storageService.deleteAtUrl(fileLocation)).called();
@@ -144,10 +144,9 @@ describe('event creation', () => {
     // verifying correct error thrown
     const cover = FileFactory.image(Config.file.MAX_EVENT_COVER_FILE_SIZE / 2);
     const storageService = Mocks.storage(fileLocation);
-    const eventController = ControllerFactory.event(conn, storageService);
+    const eventController = ControllerFactory.event(conn, instance(storageService));
     await expect(eventController.createEvent(cover, createEventRequest, admin))
       .rejects.toThrow('Start date after end date');
-    verify(storageService.deleteAtUrl(fileLocation)).called();
   });
 });
 

--- a/tests/event.test.ts
+++ b/tests/event.test.ts
@@ -1,5 +1,6 @@
 import * as moment from 'moment';
 import { ForbiddenError } from 'routing-controllers';
+import { anything, instance, verify } from 'ts-mockito';
 import { MediaType, UserAccessType } from '../types';
 import { ControllerFactory } from './controllers';
 import { DatabaseConnection, EventFactory, PortalState, UserFactory } from './data';
@@ -8,7 +9,6 @@ import { EventModel } from '../models/EventModel';
 import Mocks from './mocks/MockFactory';
 import { FileFactory } from './data/FileFactory';
 import { Config } from '../config';
-import { anything, instance, verify } from 'ts-mockito';
 
 beforeAll(async () => {
   await DatabaseConnection.connect();
@@ -72,7 +72,7 @@ describe('event creation', () => {
       storageService.upload(
         cover,
         MediaType.EVENT_COVER,
-        anything()
+        anything(),
       ),
     ).called();
 

--- a/tests/event.test.ts
+++ b/tests/event.test.ts
@@ -1,10 +1,14 @@
 import * as moment from 'moment';
 import { ForbiddenError } from 'routing-controllers';
-import { UserAccessType } from '../types';
+import { MediaType, UserAccessType } from '../types';
 import { ControllerFactory } from './controllers';
 import { DatabaseConnection, EventFactory, PortalState, UserFactory } from './data';
 import { CreateEventRequest } from '../api/validators/EventControllerRequests';
 import { EventModel } from '../models/EventModel';
+import Mocks from './mocks/MockFactory';
+import { FileFactory } from './data/FileFactory';
+import { Config } from '../config';
+import { anything, verify } from 'ts-mockito';
 
 beforeAll(async () => {
   await DatabaseConnection.connect();
@@ -20,6 +24,8 @@ afterAll(async () => {
 });
 
 describe('event creation', () => {
+  const fileLocation = 'https://s3.amazonaws.com/event-cover.jpg';
+
   test('successful event creation', async () => {
     // setting up inputs
     const conn = await DatabaseConnection.get();
@@ -47,17 +53,28 @@ describe('event creation', () => {
     };
 
     // creating the event
-    const eventController = ControllerFactory.event(conn);
-    const eventResponse = await eventController.createEvent(createEventRequest, admin);
+    const cover = FileFactory.image(Config.file.MAX_EVENT_COVER_FILE_SIZE / 2);
+    const storageService = Mocks.storage(fileLocation);
+    const eventController = ControllerFactory.event(conn, storageService);
+    const eventResponse = await eventController.createEvent(cover, createEventRequest, admin);
 
     // verifying response from event creation
-    expect(eventResponse.event.cover).toEqual(event.cover);
+    expect(eventResponse.event.cover).toEqual(fileLocation);
     expect(eventResponse.event.title).toEqual(event.title);
     expect(eventResponse.event.location).toEqual(event.location);
     expect(eventResponse.event.committee).toEqual(event.committee);
     expect(eventResponse.event.start).toEqual(event.start);
     expect(eventResponse.event.end).toEqual(event.end);
     expect(eventResponse.event.pointValue).toEqual(event.pointValue);
+
+    verify(storageService.deleteAtUrl(fileLocation)).never();
+    verify(
+      storageService.upload(
+        cover,
+        MediaType.EVENT_COVER,
+        anything()
+      ),
+    ).called();
 
     // verifying response from event lookup
     const lookupEventResponse = await eventController.getOneEvent({ uuid: eventResponse.event.uuid }, user);
@@ -91,9 +108,12 @@ describe('event creation', () => {
     };
 
     // verifying correct error
-    const eventController = ControllerFactory.event(conn);
-    await expect(eventController.createEvent(createEventRequest, user))
+    const cover = FileFactory.image(Config.file.MAX_EVENT_COVER_FILE_SIZE / 2);
+    const storageService = Mocks.storage(fileLocation);
+    const eventController = ControllerFactory.event(conn, storageService);
+    await expect(eventController.createEvent(cover, createEventRequest, user))
       .rejects.toThrow(ForbiddenError);
+    verify(storageService.deleteAtUrl(fileLocation)).called();
   });
 
   test('throws error when start date later than end date', async () => {
@@ -122,9 +142,12 @@ describe('event creation', () => {
     };
 
     // verifying correct error thrown
-    const eventController = ControllerFactory.event(conn);
-    await expect(eventController.createEvent(createEventRequest, admin))
+    const cover = FileFactory.image(Config.file.MAX_EVENT_COVER_FILE_SIZE / 2);
+    const storageService = Mocks.storage(fileLocation);
+    const eventController = ControllerFactory.event(conn, storageService);
+    await expect(eventController.createEvent(cover, createEventRequest, admin))
       .rejects.toThrow('Start date after end date');
+    verify(storageService.deleteAtUrl(fileLocation)).called();
   });
 });
 


### PR DESCRIPTION
# Info

Closes **190**. (If there is no issue for this pull request yet, please create one or
delete this line if the pull request is for a very minor tweak).

# Description

What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context.

Added create event cover to create event route. Allows event creation to work with only one api call.

## Changes

- Uploads cover photo in create event route and adds it to the event object
- Deletes the cover photo if event creation fails

# Type of Change

- [X] Patch (non-breaking change/bugfix)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (A change to a README/description)
- [ ] Continuous Integration/DevOps Change (Related to deployment steps, continuous integration
      workflows, linting, etc.)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

If you've selected Patch, Minor, or Major as your change type, **make sure to bump the version before merging in `package.json`!**
# Testing

I have tested that my changes fully resolve the linked issue ...

- [X] locally.
- [ ] on the testing API/testing database.
- [ ] with appropriate Postman routes. Screenshots are included below.

# Checklist

- [X] I have performed a self-review of my own code.
- [X] I have followed the style guidelines of this project.
- [ ] I have appropriately edited the API version in the `package.json` file.
- [X] My changes produce no new warnings.

# Screenshots

Please include a screenshot of your Postman testing passing successfully.