### PR TITLE
Fix ability to move merch item under another collection

### DIFF
--- a/services/MerchStoreService.ts
+++ b/services/MerchStoreService.ts
@@ -343,10 +343,12 @@ export default class MerchStoreService {
 
       if (updatedCollection) {
         const collection = await Repositories
-          .merchStoreCollection(txn)
-          .findByUuid(updatedCollection);
+        .merchStoreCollection(txn)
+        .findByUuid(updatedCollection);
         if (!collection) throw new NotFoundError('Merch collection not found');
+        updatedItem.collection = collection;
       }
+
       return merchItemRepository.upsertMerchItem(updatedItem);
     });
   }

--- a/services/MerchStoreService.ts
+++ b/services/MerchStoreService.ts
@@ -343,8 +343,8 @@ export default class MerchStoreService {
 
       if (updatedCollection) {
         const collection = await Repositories
-        .merchStoreCollection(txn)
-        .findByUuid(updatedCollection);
+          .merchStoreCollection(txn)
+          .findByUuid(updatedCollection);
         if (!collection) throw new NotFoundError('Merch collection not found');
         updatedItem.collection = collection;
       }

--- a/tests/merchStore.test.ts
+++ b/tests/merchStore.test.ts
@@ -651,9 +651,9 @@ describe('merch item edits', () => {
     expect(getMerchItemResponse.item.collection.uuid).toEqual(merchItemEdits.collection);
 
     // test collection update
-    const oldCollectionParams = {uuid: oldCollection.uuid };
+    const oldCollectionParams = { uuid: oldCollection.uuid };
     const getOldMerchCollectionResponse = await merchStoreController.getOneMerchCollection(oldCollectionParams, admin);
-    const newCollectionParams = {uuid: collection.uuid };
+    const newCollectionParams = { uuid: collection.uuid };
     const getNewMerchCollectionResponse = await merchStoreController.getOneMerchCollection(newCollectionParams, admin);
 
     expect(getOldMerchCollectionResponse.collection.items.length).toBe(0);


### PR DESCRIPTION
# Info

Closes **#433**.

# Description

What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context.

enable collection property to be editable through PATCH /item/:uuid

## Changes

edited the logic for merch store service over itemedit

# Type of Change

- [x] Patch (non-breaking change/bugfix)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (A change to a README/description)
- [ ] Continuous Integration/DevOps Change (Related to deployment steps, continuous integration
      workflows, linting, etc.)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

If you've selected Patch, Minor, or Major as your change type, **make sure to bump the version before merging in `package.json`!**
# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally.
- [ ] on the testing API/testing database.
- [ ] with appropriate Postman routes. Screenshots are included below.

# Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have followed the style guidelines of this project.
- [ ] I have appropriately edited the API version in the `package.json` file.
- [ ] My changes produce no new warnings.

# Screenshots

Please include a screenshot of your Postman testing passing successfully.