### PR TITLE
Fix Bug Allowing Users to Reschedule to a Full Pickup Event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acmucsd/membership-portal",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "REST API for ACM UCSD's membership portal.",
   "main": "index.d.ts",
   "files": [

--- a/services/MerchStoreService.ts
+++ b/services/MerchStoreService.ts
@@ -536,10 +536,10 @@ export default class MerchStoreService {
 
       // Verify that this order would not set the pickup event's order count
       // over the order limit
-      const currentOrderCount = pickupEvent.orders.filter((o) => o.status !== OrderStatus.CANCELLED).length;
-      if (currentOrderCount >= pickupEvent.orderLimit) {
+      if(MerchStoreService.isPickupEventOrderLimitFull(pickupEvent)) {
         throw new UserError('This merch pickup event is full! Please choose a different pickup event');
       }
+
       const totalCost = MerchStoreService.totalCost(originalOrder, itemOptions);
       const merchOrderRepository = Repositories.merchOrder(txn);
 
@@ -682,6 +682,11 @@ export default class MerchStoreService {
     return new Date() > moment(pickupEvent.start).subtract(2, 'days').toDate();
   }
 
+  private static isPickupEventOrderLimitFull(pickupEvent: OrderPickupEventModel): boolean {
+    const currentOrderCount = pickupEvent.orders.filter((o) => o.status !== OrderStatus.CANCELLED).length;
+    return currentOrderCount >= pickupEvent.orderLimit;
+  }
+
   /**
    * Changes the pickup event of an order to a new one. The new pickup event must start more than 2 calendar
    * days after the current time.
@@ -707,6 +712,9 @@ export default class MerchStoreService {
       if (!newPickupEventForOrder) throw new NotFoundError('Order pickup event not found');
       if (MerchStoreService.isLessThanTwoDaysBeforePickupEvent(newPickupEventForOrder)) {
         throw new UserError('Cannot change order pickup to an event that starts in less than 2 days');
+      }
+      if(MerchStoreService.isPickupEventOrderLimitFull(newPickupEventForOrder)) {
+        throw new UserError('This merch pickup event is full! Please choose a different pickup event');
       }
       const orderInfo = await MerchStoreService.buildOrderUpdateInfo(order, newPickupEventForOrder, txn);
       await this.emailService.sendOrderPickupUpdated(user.email, user.firstName, orderInfo);

--- a/services/MerchStoreService.ts
+++ b/services/MerchStoreService.ts
@@ -536,7 +536,7 @@ export default class MerchStoreService {
 
       // Verify that this order would not set the pickup event's order count
       // over the order limit
-      if(MerchStoreService.isPickupEventOrderLimitFull(pickupEvent)) {
+      if (MerchStoreService.isPickupEventOrderLimitFull(pickupEvent)) {
         throw new UserError('This merch pickup event is full! Please choose a different pickup event');
       }
 
@@ -713,7 +713,7 @@ export default class MerchStoreService {
       if (MerchStoreService.isLessThanTwoDaysBeforePickupEvent(newPickupEventForOrder)) {
         throw new UserError('Cannot change order pickup to an event that starts in less than 2 days');
       }
-      if(MerchStoreService.isPickupEventOrderLimitFull(newPickupEventForOrder)) {
+      if (MerchStoreService.isPickupEventOrderLimitFull(newPickupEventForOrder)) {
         throw new UserError('This merch pickup event is full! Please choose a different pickup event');
       }
       const orderInfo = await MerchStoreService.buildOrderUpdateInfo(order, newPickupEventForOrder, txn);

--- a/tests/merchOrder.test.ts
+++ b/tests/merchOrder.test.ts
@@ -1714,6 +1714,62 @@ describe('merch order pickup events', () => {
     expect(persistedPickupEvent.pickupEvent.orderLimit).toEqual(2);
   });
 
+  test('members cannot update their orders\' pickup events if the new pickup event is full', async () => {
+    const conn = await DatabaseConnection.get();
+    const member = UserFactory.fake({ credits: 10000 });
+    const item = MerchFactory.fakeItem({
+      hidden: false,
+      monthlyLimit: 100,
+    });
+    const option = MerchFactory.fakeOption({
+      item,
+      quantity: 2,
+      price: 2000,
+    });
+    const firstPickupEvent = MerchFactory.fakeFutureOrderPickupEvent({
+      orderLimit: 1,
+    });
+
+    const secondPickupEvent = MerchFactory.fakeFutureOrderPickupEvent({
+      orderLimit: 1,
+    });
+
+    await new PortalState()
+      .createUsers(member)
+      .createMerchItem(item)
+      .createMerchItemOptions(option)
+      .createOrderPickupEvents(firstPickupEvent, secondPickupEvent)
+      .orderMerch(member, [{ option, quantity: 1 }], firstPickupEvent)
+      .write();
+
+    const emailService = mock(EmailService);
+    when(emailService.sendOrderConfirmation(member.email, member.firstName, anything()))
+      .thenResolve();
+
+    // place order to secondPickupEvent
+    const order = [
+      {
+        option: option.uuid,
+        quantity: 1,
+      },
+    ];
+    const placeMerchOrderRequest = {
+      order,
+      pickupEvent: secondPickupEvent.uuid,
+    };
+
+    const merchController = ControllerFactory.merchStore(conn, instance(emailService));
+    const placedOrderResponse = await merchController.placeMerchOrder(placeMerchOrderRequest, member);
+    const placedOrder = placedOrderResponse.order;
+
+    // attempt to reschedule to firstPickupEvent
+    const orderParams = { uuid: placedOrder.uuid };
+    const newPickupEventParams = { pickupEvent: firstPickupEvent.uuid };
+    await expect(merchController.rescheduleOrderPickup(orderParams, newPickupEventParams, member))
+      .rejects
+      .toThrow('This merch pickup event is full! Please choose a different pickup event');
+  });
+
   test('placing an order with a pickup event that has reached the order limit fails', async () => {
     const conn = await DatabaseConnection.get();
     const member = UserFactory.fake({ points: 100 });


### PR DESCRIPTION
# Description

What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context.

Users can reschedule to full pickup events and this is cooking the hardworking merch store managers

## Changes

- Added extra validation prior to rescheduling the order
- Added it to a private method so I threw it in for placing order as well

# Type of Change

- [x] Patch (non-breaking change/bugfix)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (A change to a README/description)
- [ ] Continuous Integration/DevOps Change (Related to deployment steps, continuous integration
      workflows, linting, etc.)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

If you've selected Patch, Minor, or Major as your change type, **make sure to bump the version before merging in `package.json`!**
# Testing

I have tested that my changes fully resolve the linked issue ...

- [ ] locally.
- [ ] on the testing API/testing database.
- [ ] with appropriate Postman routes. Screenshots are included below.

# Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have followed the style guidelines of this project.
- [ ] I have appropriately edited the API version in the `package.json` file.
- [ ] My changes produce no new warnings.

# Screenshots

Please include a screenshot of your Postman testing passing successfully.